### PR TITLE
fix documentation typo

### DIFF
--- a/docfx~/index.md
+++ b/docfx~/index.md
@@ -1,6 +1,6 @@
 # NDM Framework
 
-NFM Framework ("Nademof" for short) is a framework for running non-destructive build plugins when building avatars for
+NDM Framework ("Nademof" for short) is a framework for running non-destructive build plugins when building avatars for
 VRChat (and, eventually, for other VRSNS platforms).
 
 ## Why is this needed?


### PR DESCRIPTION
I've found a typo that should be "NDM Framework". The last line seems to be some kind of whitespace changes.