### PR TITLE
fix: Time resolution on the plugin sequence display is actually milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Create ApplyOnPlayGlobalActivator correctly when creating and opening scenes (#31)
+- Time resolution on the plugin sequence display is milliseconds, not 0.01 ms (#43)
 
 ### Changed
 

--- a/Editor/API/BuildContext.cs
+++ b/Editor/API/BuildContext.cs
@@ -252,7 +252,7 @@ namespace nadena.dev.ndmf
                 Stopwatch sw2 = new Stopwatch();
                 sw2.Start();
                 DeactivateExtensionContext(ty);
-                deactivationTimes = deactivationTimes.Add(ty, sw2.ElapsedMilliseconds);
+                deactivationTimes = deactivationTimes.Add(ty, sw2.Elapsed.TotalMilliseconds);
             }
 
             ImmutableDictionary<Type, double> activationTimes = ImmutableDictionary<Type, double>.Empty;
@@ -261,7 +261,7 @@ namespace nadena.dev.ndmf
                 Stopwatch sw2 = new Stopwatch();
                 sw2.Start();
                 ActivateExtensionContext(ty);
-                activationTimes = activationTimes.Add(ty, sw2.ElapsedMilliseconds);
+                activationTimes = activationTimes.Add(ty, sw2.Elapsed.TotalMilliseconds);
             }
 
             Stopwatch passTimer = new Stopwatch();
@@ -283,7 +283,7 @@ namespace nadena.dev.ndmf
             
             BuildEvent.Dispatch(new BuildEvent.PassExecuted(
                 pass.InstantiatedPass.QualifiedName,
-                passTimer.ElapsedMilliseconds,
+                passTimer.Elapsed.TotalMilliseconds,
                 activationTimes,
                 deactivationTimes
             ));


### PR DESCRIPTION
It looks in 10us / 0.01 ms on the gui but previously actually in milliseconds.