### PR TITLE
add `NDMF` scripting define

### DIFF
--- a/Editor/DefineSymbolsManager.cs
+++ b/Editor/DefineSymbolsManager.cs
@@ -1,0 +1,19 @@
+﻿using System.Linq;
+using UnityEditor;
+
+namespace nadena.dev.ndmf {
+    [InitializeOnLoad]
+    public class DefineSymbolsManager {
+        private const string DefineName = "NDMF";
+
+        static DefineSymbolsManager()
+        {
+            var defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone).Split(';').ToList();
+            if (!defines.Contains(DefineName))
+            {
+                defines.Add(DefineName);
+                PlayerSettings.SetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone, string.Join(";", defines));
+            }
+        }
+    }
+}

--- a/Editor/DefineSymbolsManager.cs.meta
+++ b/Editor/DefineSymbolsManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 96c0059f62a54738851430d1d93204cf
+timeCreated: 1698070481


### PR DESCRIPTION
I want to submit a PR to VRCFury to let it build as a ndmf phase, if ndmf is in the project. That should improve its compatibility and reproducability with other tools like MA or my own tool.
In order for it to use NDMF when available a scripting define would be ideal.

This PR adds code, which adds the scripting define `NDMF` on `[IntializedOnLoad]` if it doesn't exist already.

closes #66 