### PR TITLE
fix: compatibility issues with av3emu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue where apply on play might not work when multiple scenes are open (#61)
+- Fixed an issue where Apply on Play would not work properly when Lyuma's Av3Emulator had preprocess hooks disabled
+  (bdunderscore/modular-avatar#516) (#64)
 
 ### Changed
 

--- a/Runtime/nadena.dev.ndmf.runtime.asmdef
+++ b/Runtime/nadena.dev.ndmf.runtime.asmdef
@@ -1,19 +1,26 @@
 {
-  "name": "nadena.dev.ndmf.runtime",
-  "references": [],
-  "includePlatforms": [],
-  "excludePlatforms": [],
-  "allowUnsafeCode": false,
-  "overrideReferences": false,
-  "precompiledReferences": [],
-  "autoReferenced": true,
-  "defineConstraints": [],
-  "versionDefines": [
-    {
-      "name": "com.vrchat.avatars",
-      "expression": "",
-      "define": "NDMF_VRCSDK3_AVATARS"
-    }
-  ],
-  "noEngineReferences": false
+    "name": "nadena.dev.ndmf.runtime",
+    "references": [
+        "GUID:ad78a2bc77b7491eb34cece69bb8f0e6"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "",
+            "define": "NDMF_VRCSDK3_AVATARS"
+        },
+        {
+            "name": "lyuma.av3emulator",
+            "expression": "",
+            "define": "NDMF_LYUMA_AV3EMU"
+        }
+    ],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
Fixes issues where apply on play would be suppressed when av3emu is in the
scene but preprocess hooks are disabled.

Fixes: bdunderscore/modular-avatar#516
Fixes: #64
