### PR TITLE
feat: add an API sketch for a platform-support-declaration system

### DIFF
--- a/Editor/API/Attributes/AvatarPlatform.cs
+++ b/Editor/API/Attributes/AvatarPlatform.cs
@@ -1,0 +1,13 @@
+﻿namespace nadena.dev.ndmf
+{
+    /// <summary>
+    /// Declares which platforms a plugin or pass will execute for. Plugins and passes which execute for "Generic" will
+    /// always execute; otherwise, you can declare a specific platform or platforms to support.
+    /// </summary>
+    public enum AvatarPlatform
+    {
+        Generic,
+        VRChat,
+        UniVRM
+    }
+}

--- a/Editor/API/Attributes/AvatarPlatform.cs
+++ b/Editor/API/Attributes/AvatarPlatform.cs
@@ -6,11 +6,56 @@ namespace nadena.dev.ndmf
     /// Declares which platforms a plugin or pass will execute for. Plugins and passes which execute for "Generic" will
     /// always execute; otherwise, you can declare a specific platform or platforms to support.
     /// </summary>
-    public enum AvatarPlatform
+    public sealed class AvatarPlatform
     {
-        Generic,
-        VRChat,
-        UniVRM
+        public static AvatarPlatform Generic = AvatarPlatform.Named("Generic");
+        public static AvatarPlatform VRChat = AvatarPlatform.Named("VRChat");
+        public static AvatarPlatform UniVRM = AvatarPlatform.Named("UniVRM");
+        
+        public string Name { get; }
+
+        private AvatarPlatform(string name)
+        {
+            Name = name;
+        }
+
+        /// <summary>
+        /// Constructs an AvatarPlatform using a bare string for a name. This can be used to declare support for
+        /// specific platforms without needing to take a compile-time dependency on that platform's driver package.
+        ///
+        /// AvatarPlatforms with the same name will compare equal.
+        /// </summary>
+        /// <param name="name">the name of the platform</param>
+        /// <returns>an AvatarPlatform object wrapping that name</returns>
+        public static AvatarPlatform Named(string name)
+        {
+            return new AvatarPlatform(name);
+        }
+
+        private bool Equals(AvatarPlatform other)
+        {
+            return Name == other.Name;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return ReferenceEquals(this, obj) || obj is AvatarPlatform other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Name != null ? Name.GetHashCode() : 0);
+        }
+
+        public static bool operator ==(AvatarPlatform left, AvatarPlatform right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(AvatarPlatform left, AvatarPlatform right)
+        {
+            return !Equals(left, right);
+        }
     }
 
     /// <summary>

--- a/Editor/API/Attributes/AvatarPlatform.cs
+++ b/Editor/API/Attributes/AvatarPlatform.cs
@@ -1,4 +1,6 @@
-﻿namespace nadena.dev.ndmf
+﻿using UnityEngine;
+
+namespace nadena.dev.ndmf
 {
     /// <summary>
     /// Declares which platforms a plugin or pass will execute for. Plugins and passes which execute for "Generic" will
@@ -9,5 +11,19 @@
         Generic,
         VRChat,
         UniVRM
+    }
+
+    /// <summary>
+    /// The platform driver provides certain common services which depend on the specific avatar platform being used -
+    /// e.g. heuristics for finding avatar roots.
+    /// </summary>
+    public abstract class PlatformDriver
+    {
+        public static AvatarPlatform CurrentPlatform => Current.Platform;
+        public static PlatformDriver Current;
+        
+        public abstract AvatarPlatform Platform { get; }
+
+        public abstract Transform FindAvatarRoot(Transform t);
     }
 }

--- a/Editor/API/Attributes/AvatarPlatform.cs.meta
+++ b/Editor/API/Attributes/AvatarPlatform.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 79c233be5f56479c9bc2ae8eda7104e0
+timeCreated: 1699600898

--- a/Editor/API/Fluent/Plugin.cs
+++ b/Editor/API/Fluent/Plugin.cs
@@ -1,6 +1,8 @@
 ﻿#region
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using nadena.dev.ndmf.fluent;
 using UnityEngine;
@@ -32,6 +34,12 @@ namespace nadena.dev.ndmf
 
         public virtual string QualifiedName => typeof(T).FullName;
         public virtual string DisplayName => QualifiedName;
+
+        /// <summary>
+        /// The set of platforms for which this plugin will be applied. By default, the plugin is always executed. 
+        /// </summary>
+        public virtual ISet<AvatarPlatform> SupportedPlatforms => ImmutableHashSet<AvatarPlatform>.Empty
+            .Add(AvatarPlatform.Generic);
 
         void IPlugin.Configure(PluginInfo info)
         {

--- a/Editor/API/Fluent/Sequence/Sequence.cs
+++ b/Editor/API/Fluent/Sequence/Sequence.cs
@@ -1,5 +1,7 @@
 ﻿#region
 
+using System;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using nadena.dev.ndmf.model;
@@ -241,6 +243,55 @@ namespace nadena.dev.ndmf.fluent
             var anonPass = new AnonymousPass(_sequenceBaseName + "/anonymous#" + inlinePassIndex++, displayName,
                 inlinePass);
             return InternalRun(anonPass, sourceFile, sourceLine);
+        }
+        
+        /// <summary>
+        /// Declares that subsequent pass declarations will run only on the specific platforms named.
+        /// <code>
+        /// sequence.OnPlatforms(AvatarPlatform.VRChat)
+        ///   .Run(VRChatSpecificMethod)
+        ///   .OnAllPlatforms()
+        ///   .Run(GenericMethod);
+        /// </code>
+        /// </summary>
+        /// <param name="platforms">The platforms to support</param>
+        /// <returns>this sequence</returns>
+        public Sequence OnPlatforms(params AvatarPlatform[] platforms)
+        {
+            var platformSeq = ImmutableHashSet.CreateRange(platforms);
+            if (platformSeq.Count == 0)
+            {
+                throw new ArgumentException("Must specify at least one platform");
+            }
+
+            if (platformSeq.Count != 1 && platformSeq.Contains(AvatarPlatform.Generic))
+            {
+                throw new ArgumentException("Cannot mix Generic with other platforms");
+            }
+
+            if (platformSeq.Count != platforms.Length)
+            {
+                throw new ArgumentException("Duplicate platforms specified");
+            }
+            
+            // TODO: actually record this somewhere
+            
+            return this;
+        }
+        
+        /// <summary>
+        /// Declares that subsequent pass declarations will run on all platforms.
+        /// <code>
+        /// sequence.OnPlatforms(AvatarPlatform.VRChat)
+        ///   .Run(VRChatSpecificMethod)
+        ///   .OnAllPlatforms()
+        ///   .Run(GenericMethod);
+        /// </code>
+        /// </summary>
+        /// <returns>this sequence</returns>
+        public Sequence OnAllPlatforms(params AvatarPlatform[] platforms)
+        {
+            return OnPlatforms(AvatarPlatform.Generic);
         }
     }
 }


### PR DESCRIPTION
This API sketch shows a way to declare what platforms a given plugin or
pass supports. Plugins/passes can either be generic - executing always
(think e.g. Modular Avatar's Merge Armature processing), or execute for
specific platforms such as VRChat or UniVRM.

Part of the intent here is that a project might have multiple VR Avatar
runtimes installed; it would be convenient to be able to bake the same
source avatar to different output formats without having to carry it
between different projects.
