### PR TITLE
chore: use name instead of guid to reference assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Assembly has duplicate references error may happens due to Unity bug (#80)
 
 ### Changed
 

--- a/Runtime/nadena.dev.ndmf.runtime.asmdef
+++ b/Runtime/nadena.dev.ndmf.runtime.asmdef
@@ -1,7 +1,7 @@
 {
     "name": "nadena.dev.ndmf.runtime",
     "references": [
-        "GUID:ad78a2bc77b7491eb34cece69bb8f0e6"
+        "lyuma.av3emulator"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
Fixes #80 