### PR TITLE
feat: improvements to InlineError APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Made some SimpleError APIs virtual (#104)
 - Exposed SafeSubst and SafeSubstByKey on SimpleError (#104)
+- Added support for passing IEnumerable as context objects for inline errors (#106)
+- Added support for a custom IErrorContext object to pass multiple context objects (#106)
+- Added support for substituting keys in the error title (#106)
 
 ### Fixed
 - Exceptions leaking out of language change callbacks break subsequent callbacks (#103)

--- a/Editor/ErrorReporting/IErrorContext.cs
+++ b/Editor/ErrorReporting/IErrorContext.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace nadena.dev.ndmf
+{
+    /// <summary>
+    /// This interface allows multiple context objects to be passed to an error in a single argument.
+    /// Passing an object implementing IErrorContext to ErrorReport methods will add all objects referenced in
+    /// ContextReferences as context objects.
+    /// </summary>
+    public interface IErrorContext
+    {
+        IEnumerable<ObjectReference> ContextReferences { get; }
+    }
+}

--- a/Editor/ErrorReporting/IErrorContext.cs.meta
+++ b/Editor/ErrorReporting/IErrorContext.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 877222c7e6ae43838c2a93e9a65e88d9
+timeCreated: 1703835170

--- a/Editor/ErrorReporting/SimpleError.cs
+++ b/Editor/ErrorReporting/SimpleError.cs
@@ -27,6 +27,12 @@ namespace nadena.dev.ndmf
         protected abstract string TitleKey { get; }
 
         /// <summary>
+        /// String substitutions to insert into the title of the error display. You can reference these with
+        /// e.g. `{0}`.
+        /// </summary>
+        protected virtual string[] TitleSubst => Array.Empty<string>();
+
+        /// <summary>
         /// The key to use for the details section of the error display. By default, this is the TitleKey + `:description`.
         /// </summary>
         protected virtual string DetailsKey => TitleKey + ":description";
@@ -89,7 +95,7 @@ namespace nadena.dev.ndmf
         /// <returns></returns>
         public virtual string FormatTitle()
         {
-            return Localizer.GetLocalizedString(TitleKey);
+            return SafeSubstByKey(TitleKey, TitleSubst);
         }
 
         /// <summary>

--- a/UnitTests~/InlineErrorAsset.po
+++ b/UnitTests~/InlineErrorAsset.po
@@ -1,0 +1,21 @@
+﻿msgid ""
+msgstr ""
+"Language: en-US\n"
+
+msgid "Errors:test"
+msgstr "Test error {0}"
+
+msgid "Errors:test:description"
+msgstr "Test error description {1}"
+
+msgid "Errors:test:hint"
+msgstr "Test error hint {2}"
+
+msgid "Errors:test2"
+msgstr "Test error {0}"
+
+msgid "Errors:test2:description"
+msgstr "Test error description {1}"
+
+msgid "Errors:test2:hint"
+msgstr "Test error hint {2} {3}"

--- a/UnitTests~/InlineErrorAsset.po.meta
+++ b/UnitTests~/InlineErrorAsset.po.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bea466c41ea24fc5aa7fe08064dd62c3
+timeCreated: 1704532676

--- a/UnitTests~/InlineErrorTests.cs
+++ b/UnitTests~/InlineErrorTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using nadena.dev.ndmf;
+using nadena.dev.ndmf.localization;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace UnitTests
+{
+    public class InlineErrorTests
+    {
+        private Localizer TEST_LOCALIZER = new Localizer("en-us", () => new List<LocalizationAsset>()
+        {
+            AssetDatabase.LoadAssetAtPath<LocalizationAsset>("Packages/nadena.dev.ndmf/UnitTests/InlineErrorAsset.po")
+        });
+
+        class CustomContext : IErrorContext
+        {
+            public List<ObjectReference> References = new List<ObjectReference>();
+            public IEnumerable<ObjectReference> ContextReferences => References;
+        }
+        
+        [Test]
+        public void TestInlineError()
+        {
+            var error = new InlineError(TEST_LOCALIZER, ErrorSeverity.Error, "Errors:test", "arg0", "arg1", "arg2");
+            
+            Assert.AreEqual("Test error arg0", error.FormatTitle());
+            Assert.AreEqual("Test error description arg1", error.FormatDetails());
+            Assert.AreEqual("Test error hint arg2", error.FormatHint());
+        }
+        
+        [Test]
+        public void TestEnumerableExpansion()
+        {
+            var or1 = new ObjectReference(null, "a");
+            var or2 = new ObjectReference(null, "b");
+            var or3 = new ObjectReference(null, "c");
+            
+            var error = new InlineError(TEST_LOCALIZER, ErrorSeverity.Error, "Errors:test2",
+                "arg0",
+                new object[]
+                {
+                    "arg1",
+                    new CustomContext()
+                    {
+                        References = new List<ObjectReference>()
+                        {
+                            or1,
+                        }
+                    },
+                    or2,
+                    or3
+                });
+            
+            Assert.AreEqual("Test error arg0", error.FormatTitle());
+            Assert.AreEqual("Test error description arg1", error.FormatDetails());
+            Assert.AreEqual("Test error hint a b", error.FormatHint());
+        }
+    }
+}

--- a/UnitTests~/InlineErrorTests.cs.meta
+++ b/UnitTests~/InlineErrorTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dcde3cf54f0a4ea3a135851dabe61134
+timeCreated: 1704532586


### PR DESCRIPTION
Adds support for using substitutions in error titles (#99) and using
IEnumerable or custom context classes to pass multiple context objects
(#96, #95).
