### PR TITLE
fix: work around VRCF's reflective hacks to ensure correct processing order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Adjusted hook processing order to improve compatibility with VRCFury (#122)
+- Worked around a hack in VRCFury that broke optimization plugins (#125)
 
 ### Removed
 

--- a/Editor/ApplyOnPlay.cs
+++ b/Editor/ApplyOnPlay.cs
@@ -62,7 +62,9 @@ namespace nadena.dev.ndmf
             {
                 var avatar = RuntimeUtil.FindAvatarInParents(component.transform);
                 if (avatar == null) return;
-                AvatarProcessor.ProcessAvatar(avatar.gameObject);
+
+                // Skip optimizing the avatar as we might have VRCFury or similar running after us.
+                AvatarProcessor.ProcessAvatar(avatar.gameObject, BuildPhase.Transforming);
             }
         }
 

--- a/Editor/VRChat/BuildFrameworkPreprocessHook.cs
+++ b/Editor/VRChat/BuildFrameworkPreprocessHook.cs
@@ -27,7 +27,7 @@ namespace nadena.dev.ndmf.VRChat
 
         public bool OnPreprocessAvatar(GameObject avatarGameObject)
         {
-            if (avatarGameObject.GetComponent<AlreadyProcessedTag>()) return true;
+            if (avatarGameObject.GetComponent<AlreadyProcessedTag>()?.processingCompleted == true) return true;
 
             try
             {
@@ -52,7 +52,7 @@ namespace nadena.dev.ndmf.VRChat
 
         public bool OnPreprocessAvatar(GameObject avatarGameObject)
         {
-            if (avatarGameObject.GetComponent<AlreadyProcessedTag>()) return true;
+            if (avatarGameObject.GetComponent<AlreadyProcessedTag>()?.processingCompleted == true) return true;
 
             var holder = avatarGameObject.GetComponent<ContextHolder>();
             if (holder == null) return true;

--- a/Runtime/AlreadyProcessedTag.cs
+++ b/Runtime/AlreadyProcessedTag.cs
@@ -6,6 +6,10 @@ namespace nadena.dev.ndmf.runtime
     [AddComponentMenu("")]
     internal class AlreadyProcessedTag : MonoBehaviour
     {
+        // VRCF creates this tag via reflection, but we're not actually done processing yet.
+        // We add this boolean so we can ignore any tags created surrepitiously by VRCF...
+        internal bool processingCompleted;
+        
         private void OnValidate()
         {
             hideFlags = HideFlags.HideAndDontSave;


### PR DESCRIPTION
This works around some of VRCFury's horrible hacks to improve compatibility between
NDMF and VRCF. In particular, we detect when VRCFury is invoking us reflectively, and
either skip optimizations (if running in play mode), or ignore VRCFury's invocation and
allow VRChat's build hooks to run us (in a build).
