### PR TITLE
fix(design-docs): fix access modifier on Pass example

### DIFF
--- a/design-docs/SEQUENCING.md
+++ b/design-docs/SEQUENCING.md
@@ -86,7 +86,7 @@ All passes and phases are (typically singleton) objects. A typical pass might lo
 ```csharp
 
 class MyPass : Pass<MyPass> {
-    public override void Execute(BuildContext context) {
+    protected override void Execute(BuildContext context) {
         // Do stuff
     }
 }


### PR DESCRIPTION
Using `public` will result in

> 'MyPass.Execute(BuildContext)': cannot change access modifiers when overriding 'protected' inherited member 'Pass<MyPass>.Execute(BuildContext)'[CS0507](https://msdn.microsoft.com/query/roslyn.query?appId%3Droslyn%26k%3Dk%28CS0507%29)