### PR TITLE
fix: ApplyOnPlay for Non-VRChat avatars and projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Fixed
+- Apply on Play did not work for non-VRChat avatars or environments (#153)
 
 ### Changed
 

--- a/Editor/InternalPasses/InternalPasses.cs
+++ b/Editor/InternalPasses/InternalPasses.cs
@@ -1,8 +1,6 @@
 ﻿#region
 
-using BestHTTP.SecureProtocol.Org.BouncyCastle.Crypto.Engines;
 using nadena.dev.ndmf.builtin;
-using nadena.dev.ndmf.localization;
 
 #endregion
 

--- a/Editor/UI/Localization/Localizer.cs
+++ b/Editor/UI/Localization/Localizer.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
-using VRC.SDKBase.Network;
 
 namespace nadena.dev.ndmf.localization
 {


### PR DESCRIPTION
I think we should just execute `AvatarProcessor.ProcessAvatar()` if VRCSDK build system happens to be unable to handle target avatar...