### PR TITLE
Fix language code not recognizable due to inconsistent case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Fixed
+- Fix language code not recognizable due to inconsistent case
 
 ### Changed
 

--- a/Editor/UI/Localization/Localizer.cs
+++ b/Editor/UI/Localization/Localizer.cs
@@ -129,10 +129,10 @@ namespace nadena.dev.ndmf.localization
                     .Select(l => languages[l])
                     .ToList();
 
-                if (languages.TryGetValue(LanguagePrefs.Language, out var lookup))
+                if (languages.TryGetValue(LanguagePrefs.Language, out var currentLookup))
                 {
                     // Always try the exact match first
-                    lookups.Insert(0, lookup);
+                    lookups.Insert(0, currentLookup);
                 }
 
                 _lookupCache = k =>

--- a/Editor/UI/Localization/Localizer.cs
+++ b/Editor/UI/Localization/Localizer.cs
@@ -71,7 +71,7 @@ namespace nadena.dev.ndmf.localization
                 })).ToList();
             };
 
-            languages = ImmutableSortedDictionary<string, Func<string, string>>.Empty;
+            languages = ImmutableSortedDictionary<string, Func<string, string>>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
             LoadLocalizations();
             _reloadLocalizations += LoadLocalizations;
         }
@@ -88,7 +88,7 @@ namespace nadena.dev.ndmf.localization
 
             if (_localizationLoader == null) return;
 
-            var newLanguages = ImmutableSortedDictionary<string, Func<string, string>>.Empty;
+            var newLanguages = ImmutableSortedDictionary<string, Func<string, string>>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
             foreach (var (lang, lookup) in _localizationLoader())
             {
                 var normalizedLang = CultureInfo.GetCultureInfo(lang).Name;
@@ -129,10 +129,10 @@ namespace nadena.dev.ndmf.localization
                     .Select(l => languages[l])
                     .ToList();
 
-                if (languages.ContainsKey(LanguagePrefs.Language))
+                if (languages.TryGetValue(LanguagePrefs.Language, out var lookup))
                 {
                     // Always try the exact match first
-                    lookups.Insert(0, languages[LanguagePrefs.Language]);
+                    lookups.Insert(0, lookup);
                 }
 
                 _lookupCache = k =>


### PR DESCRIPTION
This PR fixes language code not recognizable due to inconsistent case, discovered when we (Traditional Chinese community) working on Traditional Chinese translations.

This was not a problem when there is only Simplified Chinese as there was only one language starts with `zh-`, but since we have another variant now, it requires to matches the whole language code, letter by letter, not forgiving the cases.

I have let the dictionary ignores the letter cases by explicit tell it to use another comparer for indexing (`StringComparer.OrdinalIgnoreCase`)