### PR TITLE
feat: show qualified name in plugin sequence display

### DIFF
--- a/Editor/UI/SolverWindow.cs
+++ b/Editor/UI/SolverWindow.cs
@@ -103,7 +103,7 @@ namespace nadena.dev.ndmf.ui
                     var plugin = pass.Plugin;
                     if (plugin != priorPlugin)
                     {
-                        allItems.Add(new SolverUIItem() {id = id++, depth = 2, displayName = plugin.DisplayName});
+                        allItems.Add(new SolverUIItem() {id = id++, depth = 2, displayName = $"{plugin.DisplayName} ({plugin.QualifiedName})"});
                         priorPlugin = plugin;
                         pluginItem = allItems[allItems.Count - 1];
                     }


### PR DESCRIPTION
This would be helpful when considering dependency of new plugins.

<img width="366" alt="image" src="https://github.com/bdunderscore/ndmf/assets/74851548/b7080099-a9ca-4687-bfdf-cc2644390089">
