### PR TITLE
fix: UIElementLocalizer could fail to find strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new API to allow NDMF plugins to declare and introspect expressions parameter usage (#184)
 
 ### Fixed
+- UIElementLocalizer could fail to find localized strings in some cases (#189)
 
 ### Changed
 

--- a/Editor/UI/Localization/UIElementLocalizer.cs
+++ b/Editor/UI/Localization/UIElementLocalizer.cs
@@ -8,7 +8,7 @@ namespace nadena.dev.ndmf.localization
 {
     internal class UIElementLocalizer
     {
-        private static Dictionary<Type, Func<VisualElement, Action>> _localizers =
+        private Dictionary<Type, Func<VisualElement, Action>> _localizers =
             new Dictionary<Type, Func<VisualElement, Action>>();
 
         private readonly Localizer _localizer;


### PR DESCRIPTION
The localizer was sharing a static map, which captured the localizer,
across multiple plugins/localizers.
