### PR TITLE
feat: add a UI to supply a reasonable font for a language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a new API to allow NDMF plugins to declare and introspect expressions parameter usage (#184)
+- Added an API to select a non-broken font for use in UI Elements based on the current locale (#190)
 
 ### Fixed
 - UIElementLocalizer could fail to find localized strings in some cases (#189)

--- a/COPYING.md
+++ b/COPYING.md
@@ -1,6 +1,6 @@
 ﻿MIT License
 
-Copyright (c) 2023 bd_ (and other contributors)
+Copyright (c) 2023-2024 bd_ (and other contributors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Editor/UI/Localization/LanguagePrefs.cs
+++ b/Editor/UI/Localization/LanguagePrefs.cs
@@ -101,7 +101,12 @@ namespace nadena.dev.ndmf.localization
             lock (_onLanguageChangeCallbacks)
             {
                 _onLanguageChangeCallbacks.Add(op);
-                _targetRefs.AddOrUpdate(handle, finalizer);
+                // _targetRefs.AddOrUpdate(handle, finalizer); - not supported on 2019
+                if (_targetRefs.TryGetValue(handle, out var _))
+                {
+                    _targetRefs.Remove(handle);
+                }
+                _targetRefs.Add(handle, finalizer);
             }
         }
 

--- a/Editor/UI/Localization/LanguagePrefs.cs
+++ b/Editor/UI/Localization/LanguagePrefs.cs
@@ -9,7 +9,9 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using UnityEditor;
 using UnityEngine;
+#if UNITY_2022_1_OR_NEWER
 using UnityEngine.TextCore.Text;
+#endif
 using UnityEngine.UIElements;
 
 #endregion

--- a/Editor/UI/Localization/LanguagePrefs.cs
+++ b/Editor/UI/Localization/LanguagePrefs.cs
@@ -9,6 +9,8 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.TextCore.Text;
+using UnityEngine.UIElements;
 
 #endregion
 
@@ -49,6 +51,8 @@ namespace nadena.dev.ndmf.localization
 
         // TODO: Move to a single ConditionalWeakTable once we can use .NET 7 (which allows us to iterate this)
         private static HashSet<Action> _onLanguageChangeCallbacks = new HashSet<Action>();
+
+        private static Dictionary<VisualElement, Action> _fontUpdateCallbacks = new Dictionary<VisualElement, Action>();
 
         private sealed class ElementFinalizer
         {
@@ -95,7 +99,7 @@ namespace nadena.dev.ndmf.localization
             lock (_onLanguageChangeCallbacks)
             {
                 _onLanguageChangeCallbacks.Add(op);
-                _targetRefs.Add(handle, finalizer);
+                _targetRefs.AddOrUpdate(handle, finalizer);
             }
         }
 
@@ -104,6 +108,18 @@ namespace nadena.dev.ndmf.localization
             lock (_onLanguageChangeCallbacks)
             {
                 foreach (Action op in new List<Action>(_onLanguageChangeCallbacks))
+                {
+                    try
+                    {
+                        op();
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(e);
+                    }
+                }
+                
+                foreach (Action op in _fontUpdateCallbacks.Values)
                 {
                     try
                     {
@@ -178,5 +194,96 @@ namespace nadena.dev.ndmf.localization
         {
             RegisteredLanguages = RegisteredLanguages.Add(languageCode.ToLowerInvariant());
         }
+
+        #if UNITY_2022_1_OR_NEWER
+        private static IDictionary<string, StyleFontDefinition> FontCache =
+            new Dictionary<string, StyleFontDefinition>(); 
+
+        private static StyleFontDefinition PreferredFont => TryLoadFontForLanguage(Language);
+
+        private static StyleFontDefinition TryLoadFontForLanguage(string lang)
+        {
+            if (FontCache.TryGetValue(lang, out var font)) return font;
+            
+            var definitions = System.IO.File.ReadAllLines("Packages/nadena.dev.ndmf/Editor/UI/Localization/font_preferences.txt");
+
+            FontAsset currentFont = null;
+            foreach (var line in definitions)
+            {
+                if (line.StartsWith("#")) continue;
+                var parts = line.Split('=');
+                
+                if (!lang.StartsWith(parts[0])) continue;
+                
+                var loadedFont = FontAsset.CreateFontAsset(parts[1], "");
+                if (loadedFont == null) continue;
+
+                if (currentFont == null)
+                {
+                    currentFont = loadedFont;
+                    currentFont.fallbackFontAssetTable = new List<FontAsset>();
+                }
+                else
+                {
+                    currentFont.fallbackFontAssetTable.Add(loadedFont);
+                }
+            }
+            
+            if (currentFont == null)
+            {
+                font = new StyleFontDefinition(StyleKeyword.Null);
+            }
+            else
+            {
+                font = new StyleFontDefinition(currentFont);
+            }
+            
+            FontCache[lang] = font;
+
+            return font;
+        }
+
+        /// <summary>
+        /// Arranges to set the inheritable font style for a given visual element to the NDMF-bundled font for this
+        /// language, if any.
+        /// </summary>
+        /// <param name="elem"></param>
+        public static void ApplyFontPreferences(VisualElement elem)
+        {
+            elem.UnregisterCallback<AttachToPanelEvent>(AttachToPanelForFont);
+            elem.UnregisterCallback<DetachFromPanelEvent>(DetachFromPanelForFont);
+            
+            elem.RegisterCallback<AttachToPanelEvent>(AttachToPanelForFont);
+            elem.RegisterCallback<DetachFromPanelEvent>(DetachFromPanelForFont);
+            
+            UpdateElementFont(elem);
+        }
+
+        private static void AttachToPanelForFont(AttachToPanelEvent evt)
+        {
+            var elem = evt.target as VisualElement;
+            if (elem == null) return;
+            
+            _fontUpdateCallbacks[elem] = () => UpdateElementFont(elem);
+            UpdateElementFont(elem);
+        }
+
+        private static void DetachFromPanelForFont(DetachFromPanelEvent evt)
+        {
+            var elem = evt.target as VisualElement;
+            if (elem == null) return;
+            
+            _fontUpdateCallbacks.Remove(elem);
+        }
+
+        private static void UpdateElementFont(VisualElement elem)
+        {
+            elem.style.unityFontDefinition = PreferredFont;
+        }
+        #else
+        public static void ApplyFontPreferences(VisualElement elem) {
+            // Unity 2019 users will need to deal with garbage font rendering, sorry.
+        }
+        #endif
     }
 }

--- a/Editor/UI/Localization/UIElementLocalizer.cs
+++ b/Editor/UI/Localization/UIElementLocalizer.cs
@@ -1,8 +1,11 @@
-﻿using System;
+﻿#region
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using UnityEngine.UIElements;
+
+#endregion
 
 namespace nadena.dev.ndmf.localization
 {
@@ -21,6 +24,7 @@ namespace nadena.dev.ndmf.localization
         internal void Localize(VisualElement elem)
         {
             WalkTree(elem);
+            LanguagePrefs.ApplyFontPreferences(elem);
         }
 
         private void WalkTree(VisualElement elem)

--- a/Editor/UI/Localization/font_preferences.txt
+++ b/Editor/UI/Localization/font_preferences.txt
@@ -1,0 +1,4 @@
+﻿# Default (base) font
+=Arial
+# Matches ja-*
+ja-=Meiryo UI

--- a/Editor/UI/Localization/font_preferences.txt
+++ b/Editor/UI/Localization/font_preferences.txt
@@ -1,4 +1,7 @@
 ﻿# Default (base) font
+=Verdana
+=Tahoma
 =Arial
 # Matches ja-*
+ja-=Yu Gothic UI
 ja-=Meiryo UI

--- a/Editor/UI/Localization/font_preferences.txt.meta
+++ b/Editor/UI/Localization/font_preferences.txt.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d5528ba7fd6143f3a5f973ea740740ad
+timeCreated: 1710412745


### PR DESCRIPTION
Initially, we've only added support for ja-jp, but we'll follow up with
zh-* and kr-* later (once a translator can recommend an appropriate font file).
