### PR TITLE
chore: Noto Sans CJK JPをフォントチェインに追加

### DIFF
--- a/Editor/UI/Localization/font_preferences.txt
+++ b/Editor/UI/Localization/font_preferences.txt
@@ -5,6 +5,8 @@
 # Matches ja-*
 ja-=Yu Gothic UI
 ja-=Meiryo UI
+# non-Windows may not have preceding fonts, so attempt to set following fonts:
+ja-=Noto Sans CJK JP
 # Matches zh-*
 zh-hant=Microsoft JhengHei UI
 zh-hans=Microsoft YaHei UI


### PR DESCRIPTION
*このパッチは @KisaragiEffective による目視での確認作業が必要です。*
文脈: Yu Gothic UIとMeiryo UIが存在しない可能性があるプラットフォーム (具体的にはLinuxディストリビューション) でフォントのウェイト問題を踏まないようにするために、Noto Sans CJK JPを追加しました。