### PR TITLE
chore: rename NDMF Error Report to NDMF Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+- Renamed `NDMF Error Report` to `NDMF Console` (#222)
+- Changed Japanese strings a bit (#222)
+
+### Removed
+
+### Security
+
+### Deprecated
+
 ## [1.4.0] - [2024-03-27]
 
 ### Added

--- a/Editor/ErrorReporting/UI/ErrorReportWindow.cs
+++ b/Editor/ErrorReporting/UI/ErrorReportWindow.cs
@@ -22,6 +22,7 @@ namespace nadena.dev.ndmf.ui
 
     #endregion
 
+    // Note: Due to historical reason, "NDMF Console" is internally called "Error Report".
     public sealed class ErrorReportWindow : EditorWindow
     {
         // Disables displaying the error report window (for tests)
@@ -206,7 +207,6 @@ namespace nadena.dev.ndmf.ui
 
         /// <summary>
         /// Shows the error report window, displaying the last error report generated.
-        /// Note: "Error Report" window has been renamed to "NDMF Console".
         /// </summary>
         [MenuItem("Tools/NDM Framework/Show NDMF Console")]
         public static void ShowErrorReportWindow()
@@ -292,7 +292,6 @@ namespace nadena.dev.ndmf.ui
 
         /// <summary>
         /// Shows the error report window, displaying a specific error report.
-        /// Note: "Error Report" window has been renamed to "NDMF Console".
         /// </summary>
         /// <param name="report"></param>
         public static void ShowReport(ErrorReport report)
@@ -307,7 +306,6 @@ namespace nadena.dev.ndmf.ui
 
         /// <summary>
         /// Shows the error report window, displaying a specific avatar and its error report (if any).
-        /// Note: "Error Report" window has been renamed to "NDMF Console".
         /// </summary>
         /// <param name="avatarRoot"></param>
         public static void ShowReport(GameObject avatarRoot)

--- a/Editor/ErrorReporting/UI/ErrorReportWindow.cs
+++ b/Editor/ErrorReporting/UI/ErrorReportWindow.cs
@@ -207,7 +207,7 @@ namespace nadena.dev.ndmf.ui
         /// <summary>
         /// Shows the error report window, displaying the last error report generated.
         /// </summary>
-        [MenuItem("Tools/NDM Framework/Show Error Report")]
+        [MenuItem("Tools/NDM Framework/Show NDMF Console")]
         public static void ShowErrorReportWindow()
         {
             if (Application.isBatchMode || DISABLE_WINDOW) return; // headless unit tests
@@ -298,7 +298,7 @@ namespace nadena.dev.ndmf.ui
             if (Application.isBatchMode || DISABLE_WINDOW) return; // headless unit tests
 
             ErrorReportWindow wnd = GetWindow<ErrorReportWindow>();
-            wnd.titleContent = new GUIContent("NDMF Error Report");
+            wnd.titleContent = new GUIContent("NDMF Console");
             wnd.CurrentReport = report;
             wnd.Show();
         }
@@ -312,12 +312,12 @@ namespace nadena.dev.ndmf.ui
             if (Application.isBatchMode || avatarRoot == null || DISABLE_WINDOW) return;
 
             ErrorReportWindow wnd = GetWindow<ErrorReportWindow>();
-            wnd.titleContent = new GUIContent("NDMF Error Report");
+            wnd.titleContent = new GUIContent("NDMF Console");
             wnd.CurrentAvatar = avatarRoot;
             wnd.Show();
         }
 
-        [MenuItem("GameObject/NDM Framework/Show Error Report", false)]
+        [MenuItem("GameObject/NDM Framework/Show NDMF Console", false)]
         private static void ShowCurrentAvatarErrorReport()
         {
             if (Selection.activeGameObject == null) return;
@@ -325,7 +325,7 @@ namespace nadena.dev.ndmf.ui
             ShowReport(Selection.activeGameObject);
         }
 
-        [MenuItem("GameObject/NDM Framework/Show Error Report", true)]
+        [MenuItem("GameObject/NDM Framework/Show NDMF Console", true)]
         private static bool ShowCurrentAvatarErrorReportValidation()
         {
             return Selection.activeGameObject != null && RuntimeUtil.IsAvatarRoot(Selection.activeGameObject.transform);

--- a/Editor/ErrorReporting/UI/ErrorReportWindow.cs
+++ b/Editor/ErrorReporting/UI/ErrorReportWindow.cs
@@ -206,6 +206,7 @@ namespace nadena.dev.ndmf.ui
 
         /// <summary>
         /// Shows the error report window, displaying the last error report generated.
+        /// Note: "Error Report" window has been renamed to "NDMF Console".
         /// </summary>
         [MenuItem("Tools/NDM Framework/Show NDMF Console")]
         public static void ShowErrorReportWindow()
@@ -291,6 +292,7 @@ namespace nadena.dev.ndmf.ui
 
         /// <summary>
         /// Shows the error report window, displaying a specific error report.
+        /// Note: "Error Report" window has been renamed to "NDMF Console".
         /// </summary>
         /// <param name="report"></param>
         public static void ShowReport(ErrorReport report)
@@ -305,6 +307,7 @@ namespace nadena.dev.ndmf.ui
 
         /// <summary>
         /// Shows the error report window, displaying a specific avatar and its error report (if any).
+        /// Note: "Error Report" window has been renamed to "NDMF Console".
         /// </summary>
         /// <param name="avatarRoot"></param>
         public static void ShowReport(GameObject avatarRoot)

--- a/Editor/UI/Localization/en-US.po
+++ b/Editor/UI/Localization/en-US.po
@@ -6,7 +6,7 @@ msgid "ErrorReport:AvatarPrefix"
 msgstr "Avatar: "
 
 msgid "ErrorReport:Title"
-msgstr "Error Report"
+msgstr "NDMF Console"
 
 msgid "ErrorReport:HintFoldout"
 msgstr "Help me fix it!"
@@ -15,7 +15,7 @@ msgid "ErrorReport:TestBuild"
 msgstr "Perform Test Build"
 
 msgid "ErrorReport:NoErrors"
-msgstr "No errors to report!"
+msgstr "No informations to report!"
 
 msgid "ErrorReport:NoAvatarSelected"
 msgstr "No avatar selected."

--- a/Editor/UI/Localization/en-US.po
+++ b/Editor/UI/Localization/en-US.po
@@ -33,4 +33,4 @@ msgid "InternalError:StackTraceFoldout"
 msgstr "Show Stack Trace (please include with bug reports!)"
 
 msgid "AvatarProcessor:ProcessingFailed"
-msgstr "There were errors processing the avatar. Check the error report for details."
+msgstr "There were errors processing the avatar. Check the NDMF Console for details."

--- a/Editor/UI/Localization/ja-JP.po
+++ b/Editor/UI/Localization/ja-JP.po
@@ -30,4 +30,4 @@ msgid "InternalError:StackTraceFoldout"
 msgstr "スタックトレースを表示（バグ報告に添付してください！）"
 
 msgid "AvatarProcessor:ProcessingFailed"
-msgstr "アバター処理中にエラーが発生しました。詳しくはエラー表示をご確認ください。"
+msgstr "アバター処理中にエラーが発生しました。詳しくはNDMFコンソールをご確認ください。"

--- a/Editor/UI/Localization/ja-JP.po
+++ b/Editor/UI/Localization/ja-JP.po
@@ -3,7 +3,7 @@ msgstr ""
 "Language: ja-JP\n"
 
 msgid "ErrorReport:Title"
-msgstr "エラー表示"
+msgstr "NDMFコンソール"
 
 msgid "ErrorReport:HintFoldout"
 msgstr "直すには？"
@@ -12,10 +12,10 @@ msgid "ErrorReport:TestBuild"
 msgstr "テストビルドを実行"
 
 msgid "ErrorReport:NoErrors"
-msgstr "エラーがありません！"
+msgstr "表示する情報は特にありません。"
 
 msgid "ErrorReport:NoAvatarSelected"
-msgstr "アバターが選択されていません"
+msgstr "アバターが選択されていません。"
 
 msgid "ErrorReport:Unbuilt"
 msgstr "アバターはまだビルドされていません。"


### PR DESCRIPTION
resolve: #173 
- [x] Error Report表記の変更
- [x] 日本語での一部表示内容の変更(ついでに変えました)
- [ ] 内部名称を変更 (publicになっていたのでやっていません。表記以外変える必要が必ずしもある訳ではないので、この変更でBreaking Changeになるのが流石に少し申し訳なく…?)