### PR TITLE
If an ObjectSelector cannot be created, fall back to the label displa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Workaround VRCSDK bug where stale PhysBones state could be retained over play mode transitions (#231) 
+- Show object name when we're unable to find the actual GameObject, in error display UI (#224)
 
 ### Changed
 

--- a/Editor/ErrorReporting/UI/SimpleErrorUI.cs
+++ b/Editor/ErrorReporting/UI/SimpleErrorUI.cs
@@ -94,6 +94,10 @@ namespace nadena.dev.ndmf.ui
                     {
                         objRefs.Add(selector);
                     }
+                    else
+                    {
+                        objRefs.Add(new Label(objRef.ToString()));
+                    }
                 }
             }
         }


### PR DESCRIPTION
If an ObjectSelector cannot be created, fall back to the label display. (#223)
ErrorReport で選択ボタンを作成できない場合は、かわりにオブジェクトの名前を表示するラベルを作成して表示します。

このように動作します。
![image](https://github.com/bdunderscore/ndmf/assets/44968974/667962b8-5b1b-4080-afb8-c7051c3ad3e9)
