### PR TITLE
feat: add TextureCompressor to compress textures on serialization

### DIFF
--- a/Editor/API/TextureCompressor.cs
+++ b/Editor/API/TextureCompressor.cs
@@ -1,0 +1,143 @@
+﻿#region
+
+using nadena.dev.ndmf.util;
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+#endregion
+
+namespace nadena.dev.ndmf
+{
+    /// <summary>
+    /// This class allows you to set a particular Texture Compressor instance as the current one to be used for static
+    /// methods. This is primarily intended for unit testing.
+    /// </summary>
+    public sealed class TextureCompressorScope : IDisposable
+    {
+        private readonly TextureCompressor _oldCompressor;
+
+        public TextureCompressorScope(TextureCompressor compressor)
+        {
+            _oldCompressor = TextureCompressor.ActiveCompressor;
+            TextureCompressor.ActiveCompressor = compressor;
+        }
+
+        public void Dispose()
+        {
+            TextureCompressor.ActiveCompressor = _oldCompressor;
+        }
+    }
+
+    internal struct TextureCompression
+    {
+        public TextureFormat Format;
+        public TextureCompressionQuality Quality;
+    }
+
+    /// <summary>
+    /// The TextureCompressor keeps compression settings of registered textures; this is used to compress textures when saving textures to AssetContainer.
+    /// </summary>
+    public sealed class TextureCompressor
+    {
+        // Reference texture => compression settings
+        private readonly Dictionary<Texture2D, TextureCompression> _tex2compression =
+            new Dictionary<Texture2D, TextureCompression>();
+
+        private const TextureFormat DEFAULT_TEXTURE_FORMAT_PC = TextureFormat.DXT5;
+        private const TextureFormat DEFAULT_TEXTURE_FORMAT_ANDROID = TextureFormat.ASTC_6x6;
+        private const TextureCompressionQuality DEFAULT_COMPRESSION_QUALITY = TextureCompressionQuality.Best;
+
+        static internal TextureCompressor ActiveCompressor;
+
+        /// <summary>
+        /// Register a texture to override texture format and quality for later compression.
+        /// </summary>
+        /// <param name="tex"></param>
+        /// <param name="format"></param>
+        /// <param name="quality"></param>
+        public static void RegisterCompression(Texture2D tex, TextureFormat format, TextureCompressionQuality quality)
+        {
+            RegisterCompression(tex, format, quality, EditorUserBuildSettings.activeBuildTarget);
+        }
+
+        /// <summary>
+        /// For internal use only.
+        /// </summary>
+        /// <param name="tex"></param>
+        /// <param name="format"></param>
+        /// <param name="quality"></param>
+        /// <param name="buildTarget"></param>
+        internal static void RegisterCompression(Texture2D tex, TextureFormat format, TextureCompressionQuality quality, BuildTarget buildTarget)
+        {
+            if (ActiveCompressor == null) return;
+
+            if (tex == null) throw new NullReferenceException("tex must not be null");
+
+            if (!TextureUtility.IsSupportedFormat(format, buildTarget))
+            {
+                throw new NotSupportedException($"Unsupported texture format for {buildTarget}: {format}");
+            }
+
+            ActiveCompressor._tex2compression[tex] = new TextureCompression()
+            {
+                Format = format,
+                Quality = quality,
+            };
+        }
+
+        /// <summary>
+        /// Compress a texture with registered compression settings.
+        /// </summary>
+        /// <param name="tex"></param>
+        /// <param name="buildTarget"></param>
+        public static void CompressTexture(Texture2D tex, BuildTarget buildTarget)
+        {
+            if (ActiveCompressor == null) return;
+
+            if (tex == null) throw new NullReferenceException("tex must not be null");
+
+            if (!ActiveCompressor._tex2compression.TryGetValue(tex, out var compression))
+            {
+                var isAndroid = buildTarget == BuildTarget.Android;
+                compression = new TextureCompression()
+                {
+                    Format = isAndroid ? DEFAULT_TEXTURE_FORMAT_ANDROID : DEFAULT_TEXTURE_FORMAT_PC,
+                    Quality = DEFAULT_COMPRESSION_QUALITY
+                };
+            }
+            EditorUtility.CompressTexture(tex, compression.Format, compression.Quality);
+        }
+
+        /// <summary>
+        /// Check if a texture format is compressed.
+        /// </summary>
+        /// <param name="tex"></param>
+        /// <returns>true when the format is for compression.</returns>
+        public static bool IsCompressedTexture(Texture2D tex)
+        {
+            return !TextureUtility.IsUncompressedFormat(tex.format);
+        }
+
+        /// <summary>
+        /// Check if a texture is explicitly uncompressed.
+        /// </summary>
+        /// <param name="tex"></param>
+        /// <returns>true when the texture's format is for uncompression and the format is registered.</returns>
+        public static bool IsExplicitlyUncompressedTexture(Texture2D tex)
+        {
+            if (IsCompressedTexture(tex)) return false;
+
+            if (ActiveCompressor == null) throw new NullReferenceException("active compressor must not be null");
+
+            if (tex == null) throw new NullReferenceException("tex must not be null");
+
+            if (ActiveCompressor._tex2compression.TryGetValue(tex, out var compression))
+            {
+                return TextureUtility.IsUncompressedFormat(compression.Format);
+            }
+            return false;
+        }
+    }
+}

--- a/Editor/API/TextureCompressor.cs.meta
+++ b/Editor/API/TextureCompressor.cs.meta
@@ -1,0 +1,11 @@
+﻿fileFormatVersion: 2
+guid: 0044b01a380a706408e8b37a3e6555a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/API/Util/TextureUtility.cs
+++ b/Editor/API/Util/TextureUtility.cs
@@ -1,0 +1,107 @@
+﻿#region
+
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+#endregion
+
+namespace nadena.dev.ndmf.util
+{
+    /// <summary>
+    /// This class provides utility methods for textures.
+    /// </summary>
+    public static class TextureUtility
+    {
+        private static readonly HashSet<TextureFormat> UncompressedFormats = new HashSet<TextureFormat>
+        {
+            TextureFormat.Alpha8,
+            TextureFormat.ARGB32,
+            TextureFormat.ARGB4444,
+            TextureFormat.BGRA32,
+            TextureFormat.R16,
+            TextureFormat.R8,
+            TextureFormat.RFloat,
+            TextureFormat.RG16,
+            TextureFormat.RG32,
+            TextureFormat.RGB24,
+            TextureFormat.RGB48,
+            TextureFormat.RGB565,
+            TextureFormat.RGB9e5Float,
+            TextureFormat.RGBA32,
+            TextureFormat.RGBA4444,
+            TextureFormat.RGBA64,
+            TextureFormat.RGBAFloat,
+            TextureFormat.RGBAHalf,
+            TextureFormat.RGFloat,
+            TextureFormat.RGHalf,
+            TextureFormat.RHalf,
+            TextureFormat.YUY2
+        };
+
+        // https://docs.unity3d.com/2022.3/Documentation/Manual/class-TextureImporterOverride.html
+        private static readonly HashSet<TextureFormat> WindowsFormats = new HashSet<TextureFormat>
+        {
+            TextureFormat.BC4,
+            TextureFormat.BC5,
+            TextureFormat.BC6H,
+            TextureFormat.BC7,
+            TextureFormat.DXT1,
+            TextureFormat.DXT1Crunched,
+            TextureFormat.DXT5,
+            TextureFormat.DXT5Crunched,
+        };
+
+        // https://docs.unity3d.com/2022.3/Documentation/Manual/class-TextureImporterOverride.html
+        // Contains "partial" formats to simplify.
+        private static readonly HashSet<TextureFormat> AndroidFormats = new HashSet<TextureFormat>
+        {
+            TextureFormat.ASTC_4x4,
+            TextureFormat.ASTC_5x5,
+            TextureFormat.ASTC_6x6,
+            TextureFormat.ASTC_8x8,
+            TextureFormat.ASTC_10x10,
+            TextureFormat.ASTC_12x12,
+            TextureFormat.ASTC_HDR_4x4,
+            TextureFormat.ASTC_HDR_5x5,
+            TextureFormat.ASTC_HDR_6x6,
+            TextureFormat.ASTC_HDR_8x8,
+            TextureFormat.ASTC_HDR_10x10,
+            TextureFormat.ASTC_HDR_12x12,
+            TextureFormat.ETC2_RGB,
+            TextureFormat.ETC2_RGBA1,
+            TextureFormat.ETC2_RGBA8,
+            TextureFormat.ETC2_RGBA8Crunched,
+            TextureFormat.ETC_RGB4,
+            TextureFormat.ETC_RGB4Crunched,
+            TextureFormat.EAC_R,
+            TextureFormat.EAC_R_SIGNED,
+            TextureFormat.EAC_RG,
+            TextureFormat.EAC_RG_SIGNED,
+        };
+
+        /// <summary>
+        /// Check if a texture format is for uncompressed.
+        /// </summary>
+        /// <param name="format"></param>
+        /// <returns>true when the format is uncompressed format.</returns>
+        public static bool IsUncompressedFormat(TextureFormat format)
+        {
+            return UncompressedFormats.Contains(format);
+        }
+
+        public static bool IsSupportedFormat(TextureFormat format, BuildTarget buildTarget)
+        {
+            switch (buildTarget)
+            {
+                case BuildTarget.StandaloneWindows:
+                case BuildTarget.StandaloneWindows64:
+                    return WindowsFormats.Contains(format) || IsUncompressedFormat(format);
+                case BuildTarget.Android:
+                    return AndroidFormats.Contains(format) || IsUncompressedFormat(format);
+                default:
+                    throw new System.NotSupportedException($"Unsupported build target: {buildTarget}");
+            }
+        }
+    }
+}

--- a/Editor/API/Util/TextureUtility.cs.meta
+++ b/Editor/API/Util/TextureUtility.cs.meta
@@ -1,0 +1,11 @@
+﻿fileFormatVersion: 2
+guid: ec60176e3df9aac47a057fbf3fd90a63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ErrorReporting/UI/ErrorReportWindow.cs
+++ b/Editor/ErrorReporting/UI/ErrorReportWindow.cs
@@ -255,7 +255,7 @@ namespace nadena.dev.ndmf.ui
                 _errorList.style.display = DisplayStyle.Flex;
                 _errorList.Clear();
 
-                var errors = _report.Errors.OrderBy(e => e.Plugin.DisplayName).ToList();
+                var errors = _report.Errors.OrderBy(e => e.Plugin?.DisplayName ?? "(Unnamed)").ToList();
                 PluginBase lastPlugin = null;
 
                 foreach (var error in errors)

--- a/Editor/UI/Localization/en-US.po
+++ b/Editor/UI/Localization/en-US.po
@@ -34,3 +34,6 @@ msgstr "Show Stack Trace (please include with bug reports!)"
 
 msgid "AvatarProcessor:ProcessingFailed"
 msgstr "There were errors processing the avatar. Check the error report for details."
+
+msgid "BuildContext:UnsupportedTextureFormat"
+msgstr "{0} doesn't support {1} texture format. When this texture was created by manual bake, switch target platform then execute manual bake again."

--- a/Editor/UI/Localization/ja-JP.po
+++ b/Editor/UI/Localization/ja-JP.po
@@ -31,3 +31,6 @@ msgstr "スタックトレースを表示（バグ報告に添付してくださ
 
 msgid "AvatarProcessor:ProcessingFailed"
 msgstr "アバター処理中にエラーが発生しました。詳しくはエラー表示をご確認ください。"
+
+msgid "BuildContext:UnsupportedTextureFormat"
+msgstr "{0}で{1}フォーマットのテクスチャはサポートされていません。このテクスチャがマニュアルベイクで作成されている場合、ターゲットプラットフォームを変更した後で再度マニュアルベイクしてください。"

--- a/docfx~/execution-model.md
+++ b/docfx~/execution-model.md
@@ -124,3 +124,26 @@ dependencies on `MyPass` that are not yet satisfied, then `MyPass` will not run 
 
 Additionally, there might be multiple `WaitFor` dependencies, in which case the order in which these are executed -
 absent other constraints - is undefined.
+
+## Assets management
+
+After all passes have been executed, NDMF will automatically save the generated assets which are referenced by the
+built avatar object. So usually you don't need to worry about saving the assets manually.
+
+### Texture compression
+
+NDMF will automatically compress textures with appropriate format for the active build target.
+The default settings are:
+- PC: DXT5
+- Android: ASTC 6x6
+
+You can set texture compression settings with `TextureCompressor` class.
+
+```csharp
+sequence.Run(ctx => {
+    var texture = GenerateTexture();
+
+    // Use DXT5 with Crunch compression.
+    TextureCompressor.RegisterCompression(texture, TextureFormat.DXT5Crunched, TextureCompressionQuality.Best);
+});
+```


### PR DESCRIPTION
resolve #225 and #164

`BuildContext.Serialize()` 内で未保存のテクスチャアセットがある場合に、保存前に自動的に圧縮します。
また最後にテクスチャのフォーマットを確認し、現在のプラットフォームで非サポートの場合は警告を表示します。

![image](https://github.com/bdunderscore/ndmf/assets/74851548/8f53c545-1c9b-4d51-bfdc-20df87b1a8e8)


@anatawa12 @ReinaS-64892
関係すると思うので見てもらえると助かります。