### PR TITLE
fix: workaround VRCSDK bug where stale data is left in physbone state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- Workaround VRCSDK bug where stale PhysBones state could be retained over play mode transitions (#231) 
+
+### Security
+
 ## [1.4.0] - [2024-03-27]
 
 ### Added

--- a/Editor/VRChat/ForceReinitPhysBonesHook.cs
+++ b/Editor/VRChat/ForceReinitPhysBonesHook.cs
@@ -1,0 +1,35 @@
+﻿#region
+
+using UnityEngine;
+using VRC.SDK3.Dynamics.PhysBone.Components;
+using VRC.SDKBase.Editor.BuildPipeline;
+
+#endregion
+
+namespace nadena.dev.ndmf.VRChat
+{
+    /// <summary>
+    /// When domain reload is disabled, the VRChat physbones gizmo can leave outdated data in the VRCPhysBone component
+    /// when entering play mode. Force reinitialize the components to work around this issue.
+    ///
+    /// Note that we only do this when entering play mode, as this is runtime state, not serialized state.
+    /// </summary>
+    public class ForceReinitPhysBonesHook : IVRCSDKPreprocessAvatarCallback
+    {
+        public int callbackOrder => int.MaxValue;
+
+        public bool OnPreprocessAvatar(GameObject avatarGameObject)
+        {
+            if (Application.isPlaying)
+            {
+                foreach (var physBone in avatarGameObject.GetComponentsInChildren<VRCPhysBone>(true))
+                {
+                    physBone.InitTransforms(true);
+                    physBone.InitParameters();
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Editor/VRChat/ForceReinitPhysBonesHook.cs
+++ b/Editor/VRChat/ForceReinitPhysBonesHook.cs
@@ -1,6 +1,8 @@
 ﻿#region
 
 using UnityEngine;
+using VRC.Dynamics;
+using VRC.SDK3.Dynamics.Contact.Components;
 using VRC.SDK3.Dynamics.PhysBone.Components;
 using VRC.SDKBase.Editor.BuildPipeline;
 
@@ -26,6 +28,17 @@ namespace nadena.dev.ndmf.VRChat
                 {
                     physBone.InitTransforms(true);
                     physBone.InitParameters();
+                }
+
+                foreach (var collider in avatarGameObject.GetComponentsInChildren<VRCPhysBoneColliderBase>(true))
+                {
+                    collider.UpdateShape();
+                }
+
+                foreach (var contact in avatarGameObject.GetComponentsInChildren<ContactBase>(true))
+                {
+                    contact.UpdateShape();
+                    contact.UpdateContact();
                 }
             }
 

--- a/Editor/VRChat/ForceReinitPhysBonesHook.cs.meta
+++ b/Editor/VRChat/ForceReinitPhysBonesHook.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6831f2112c184d589f30cc68e0553ae9
+timeCreated: 1715048145


### PR DESCRIPTION
Closes: https://github.com/bdunderscore/modular-avatar/issues/845
