### PR TITLE
fix: CVRAvatar prevents removal of Animator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#257] Proxy renderers no longer appear in the hierarchy.
+- [#260] [ChilloutVR] Fix: Build fails due to CVRAvatar preventing recreation of Animator (contributed by @hai-vr)
 
 ### Changed
 


### PR DESCRIPTION
The error "Can't remove Animator because CVRAvatar (Script) depends on it" occurs in ChilloutVR avatars during the recreation of the Animator component.

This is because CVRAvatar has a RequireComponent annotation for Animator.

This commit fixes this issue by removing CVRAvatar first, and recreates it in the same way.

Tested on ChilloutVR CCK v3.9 RELEASE