### PR TITLE
feat: don't build the avatar when ChilloutVR shows the upload UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#257] Proxy renderers no longer appear in the hierarchy.
 - [#260] [ChilloutVR] Fix: Build fails due to CVRAvatar preventing recreation of Animator (contributed by @hai-vr)
+- [#261] [ChilloutVR] feat: don't build the avatar when ChilloutVR shows the upload UI (contributed by @hai-vr)
 
 ### Changed
 

--- a/Runtime/ApplyOnPlayGlobalActivator.cs
+++ b/Runtime/ApplyOnPlayGlobalActivator.cs
@@ -113,6 +113,11 @@ namespace nadena.dev.ndmf.runtime
 
             // Check if Lyuma's Av3Emulator is present and enabled; if so, we leave preprocessing up to it.
             if (Av3EmuStatusChecker.IsAv3EmuActive()) return;
+            
+#if CVR_CCK_EXISTS
+            // If the ChilloutVR SDK is installed and this is the upload dialog UI, don't process the avatar.
+            if (EditorPrefs.GetBool("m_ABI_isBuilding")) return;
+#endif
 
             foreach (var avatar in RuntimeUtil.FindAvatarsInScene(gameObject.scene))
             {


### PR DESCRIPTION
When uploading an avatar in ChilloutVR, the avatar is first built, then the editor will enter Play mode to show the upload UI. 

Entering Play mode in this way will cause the avatar to be processed a second time by NDMF, creating an unnecessary delay before uploading.

This commit skips that second processing.

Tested on ChilloutVR CCK v3.9 RELEASE