### PR TITLE
chore: defer invalidation until after dependencies finish computing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#256] Certain CommonQueries now ignore hidden and unsaved objects, to avoid infinite update loops.
+- [#269] ReactiveValues now invalidate only after their dependencies finish computation
 
 ### Removed
 

--- a/RQ-Core/ReactiveQueryScheduler.cs
+++ b/RQ-Core/ReactiveQueryScheduler.cs
@@ -22,14 +22,17 @@ namespace nadena.dev.ndmf.rq
             get
             {
                 var oldContext = SynchronizationContext.Current;
+                TaskScheduler scheduler;
                 if (SynchronizationContextOverride.Value != null)
                 {
                     SynchronizationContext.SetSynchronizationContext(SynchronizationContextOverride.Value);
+                    scheduler = TaskScheduler.FromCurrentSynchronizationContext();
+                    SynchronizationContext.SetSynchronizationContext(oldContext);
                 }
-
-                var scheduler = TaskScheduler.FromCurrentSynchronizationContext();
-
-                SynchronizationContext.SetSynchronizationContext(oldContext);
+                else
+                {
+                    scheduler = TaskScheduler.Default;
+                }
 
                 return scheduler;
             }

--- a/RQ-Core/nadena.dev.ndmf.reactive-query.core.asmdef
+++ b/RQ-Core/nadena.dev.ndmf.reactive-query.core.asmdef
@@ -1,9 +1,7 @@
 {
   "name": "nadena.dev.ndmf.reactive-query.core",
   "rootNamespace": "",
-  "references": [
-    "nadena.dev.ndmf.reactive-query.jetbrains-annotations"
-  ],
+  "references": [],
   "includePlatforms": [],
   "excludePlatforms": [],
   "allowUnsafeCode": false,
@@ -12,5 +10,5 @@
   "autoReferenced": false,
   "defineConstraints": [],
   "versionDefines": [],
-  "noEngineReferences": true
+  "noEngineReferences": false
 }

--- a/UnitTests~/RQ-StandaloneTests/TestQuery.cs
+++ b/UnitTests~/RQ-StandaloneTests/TestQuery.cs
@@ -6,6 +6,8 @@ namespace nadena.dev.ndmf.rq.StandaloneTests
 {
     internal class TestQuery<T> : ReactiveValue<T>
     {
+        private static int COUNT = 0;
+        private int n = COUNT++;
         private Func<ComputeContext, Task<T>> _value;
 
         public Func<ComputeContext, Task<T>> Value
@@ -30,7 +32,7 @@ namespace nadena.dev.ndmf.rq.StandaloneTests
 
         public override string ToString()
         {
-            return "TestQuery";
+            return "TestQuery " + n;
         }
     }
 }

--- a/UnitTests~/RQ-StandaloneTests/nadena.dev.ndmf.reactive-query.tests.standalone.asmdef
+++ b/UnitTests~/RQ-StandaloneTests/nadena.dev.ndmf.reactive-query.tests.standalone.asmdef
@@ -14,5 +14,5 @@
   "autoReferenced": false,
   "defineConstraints": [],
   "versionDefines": [],
-  "noEngineReferences": true
+  "noEngineReferences": false
 }


### PR DESCRIPTION
This is in preparation for suppressing invalidations when the result of an RQ
is unchanged.
