### PR TITLE
feat: pass ObjectRegistry to render filter nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [#287] Added PublishedValue class
+- [#288] Added support for passing ObjectRegistry to IRenderFilter (note: breaking change on alpha-only APIs)
 
 ### Fixed
 - [#283] Cached proxy objects are visible after exiting play mode 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [#287] Added PublishedValue class
-- [#288] Added support for passing ObjectRegistry to IRenderFilter (note: breaking change on alpha-only APIs)
+- [#288] Added support for passing ObjectRegistry to IRenderFilter
 
 ### Fixed
 - [#283] Cached proxy objects are visible after exiting play mode 

--- a/Editor/API/ObjectRegistry.cs
+++ b/Editor/API/ObjectRegistry.cs
@@ -2,7 +2,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+using System.Linq;
+using nadena.dev.ndmf.rq;
 using nadena.dev.ndmf.runtime;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -23,9 +24,9 @@ namespace nadena.dev.ndmf
     /// </summary>
     public sealed class ObjectRegistryScope : IDisposable
     {
-        private readonly ObjectRegistry _oldRegistry;
+        private readonly IObjectRegistry _oldRegistry;
 
-        public ObjectRegistryScope(ObjectRegistry registry)
+        public ObjectRegistryScope(IObjectRegistry registry)
         {
             _oldRegistry = ObjectRegistry.ActiveRegistry;
             ObjectRegistry.ActiveRegistry = registry;
@@ -43,61 +44,103 @@ namespace nadena.dev.ndmf
         public ObjectReference Reference;
     }
 
+    public interface IObjectRegistry
+    {
+        /// <summary>
+        ///     Returns the ObjectReference for the given object.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="create">If true, an ObjectReference will be created if one does not already exist</param>
+        /// <returns>The ObjectReference, or null if create is false and no reference exists</returns>
+        public ObjectReference GetReference(UnityObject obj, bool create = true);
+
+        /// <summary>
+        ///     Record that a particular object (asset or scene object) was replaced by a clone or transformed version.
+        ///     This will be used to track the original object in error reports.
+        /// </summary>
+        /// <param name="oldObject"></param>
+        /// <param name="newObject"></param>
+        /// <returns>The ObjectReference for the objects in question</returns>
+        public ObjectReference RegisterReplacedObject(UnityObject oldObject, UnityObject newObject);
+
+        /// <summary>
+        ///     Record that a particular object (asset or scene object) was replaced by a clone or transformed version.
+        ///     This will be used to track the original object in error reports.
+        /// </summary>
+        /// <param name="oldObject"></param>
+        /// <param name="newObject"></param>
+        /// <returns>The ObjectReference for the objects in question</returns>
+        public ObjectReference RegisterReplacedObject(ObjectReference oldObject, UnityObject newObject);
+    }
+
     /// <summary>
     /// The ObjectRegistry tracks the original position of objects on the avatar; this is used to be able to identify
     /// the source of errors after objects have been moved within the hierarchy.
     /// </summary>
-    public sealed class ObjectRegistry
+    public sealed class ObjectRegistry : IObjectRegistry
     {
         // Reference hash code => objects
-        private readonly Dictionary<int, List<Entry>> _obj2ref =
-            new Dictionary<int, List<Entry>>();
+        private readonly Dictionary<Object, ObjectReference> _obj2ref = new(new ObjectIdentityComparer<UnityObject>());
 
-        static internal ObjectRegistry ActiveRegistry;
         internal readonly Transform AvatarRoot;
+        public static IObjectRegistry ActiveRegistry { get; internal set; }
+        private readonly ObjectRegistry _parent;
 
-        public ObjectRegistry(Transform avatarRoot)
+        internal static ObjectRegistry Merge(Transform avatarRoot, IEnumerable<ObjectRegistry> inputs)
         {
-            AvatarRoot = avatarRoot;
+            var newRegistry = new ObjectRegistry(null);
+
+            foreach (var kvp in inputs.SelectMany(FlattenEntries)) newRegistry._obj2ref[kvp.Key] = kvp.Value;
+
+            return newRegistry;
+
+            IEnumerable<KeyValuePair<Object, ObjectReference>> FlattenEntries(ObjectRegistry registry)
+            {
+                while (registry != null)
+                {
+                    foreach (var kvp in registry._obj2ref) yield return kvp;
+
+                    registry = registry._parent;
+                }
+            }
         }
 
+        public ObjectRegistry(Transform avatarRoot, ObjectRegistry parent = null)
+        {
+            AvatarRoot = avatarRoot;
+            _parent = parent;
+        }
+
+        /// <summary>
+        ///     Returns the ObjectReference for the given object, using the ambient ObjectRegistry.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
         public static ObjectReference GetReference(UnityObject obj)
         {
             if (obj == null) return null;
 
-            return ActiveRegistry?._GetReference(obj) ?? new ObjectReference(obj, null);
+            return ActiveRegistry?.GetReference(obj) ?? new ObjectReference(obj, null);
         }
 
-        private ObjectReference _GetReference(UnityObject obj)
+        ObjectReference IObjectRegistry.GetReference(UnityObject obj, bool create)
         {
-            if (obj == null) return null;
-            if (!_obj2ref.TryGetValue(RuntimeHelpers.GetHashCode(obj), out var refs))
-            {
-                _obj2ref[RuntimeHelpers.GetHashCode(obj)] = refs = new List<Entry>();
-            }
+            var objref = _obj2ref.GetValueOrDefault(obj);
 
-            foreach (var r in refs)
+            if (objref != null || !create)
             {
-                if (r.Object == obj) return r.Reference;
+                return objref;
             }
 
             string path = null;
-            if (obj is GameObject go)
-            {
-                path = RuntimeUtil.RelativePath(ActiveRegistry.AvatarRoot.gameObject, go);
-            }
-            else if (obj is Component c)
-            {
-                path = RuntimeUtil.RelativePath(ActiveRegistry.AvatarRoot.gameObject, c.gameObject);
-            }
+            if (AvatarRoot == null)
+                path = "<unknown>";
+            else if (obj is GameObject go)
+                path = RuntimeUtil.RelativePath(AvatarRoot?.gameObject, go);
+            else if (obj is Component c) path = RuntimeUtil.RelativePath(AvatarRoot?.gameObject, c.gameObject);
 
-            var objref = new ObjectReference(obj, path);
-
-            refs.Add(new Entry()
-            {
-                Object = obj,
-                Reference = objref
-            });
+            objref = new ObjectReference(obj, path);
+            _obj2ref[obj] = objref;
 
             return objref;
         }
@@ -111,7 +154,14 @@ namespace nadena.dev.ndmf
         /// <returns>The ObjectReference for the objects in question</returns>
         public static ObjectReference RegisterReplacedObject(UnityObject oldObject, UnityObject newObject)
         {
-            return RegisterReplacedObject(GetReference(oldObject), newObject);
+            return ActiveRegistry?.RegisterReplacedObject(GetReference(oldObject), newObject);
+        }
+
+        ObjectReference IObjectRegistry.RegisterReplacedObject(UnityObject oldObject, UnityObject newObject)
+        {
+            // We made the mistake of creating a bunch of static wrappers that conflict with the names we want on the
+            // interface; work around this by using the interface explicitly here.
+            return ((IObjectRegistry)this).RegisterReplacedObject(GetReference(oldObject), newObject);
         }
 
         /// <summary>
@@ -123,30 +173,21 @@ namespace nadena.dev.ndmf
         /// <returns>The ObjectReference for the objects in question</returns>
         public static ObjectReference RegisterReplacedObject(ObjectReference oldObject, UnityObject newObject)
         {
-            if (ActiveRegistry == null) return oldObject;
+            return ActiveRegistry?.RegisterReplacedObject(oldObject, newObject) ?? oldObject;
+        }
 
+        ObjectReference IObjectRegistry.RegisterReplacedObject(ObjectReference oldObject, UnityObject newObject)
+        {
             if (oldObject == null) throw new NullReferenceException("oldObject must not be null");
             if (newObject == null) throw new NullReferenceException("newObject must not be null");
 
-            if (!ActiveRegistry._obj2ref.TryGetValue(RuntimeHelpers.GetHashCode(newObject), out var refs))
-            {
-                ActiveRegistry._obj2ref[RuntimeHelpers.GetHashCode(newObject)] = refs = new List<Entry>();
-            }
+            var self = (IObjectRegistry)this;
 
-            foreach (var r in refs)
-            {
-                if (r.Object == newObject)
-                {
-                    throw new ArgumentException(
-                        "RegisterReplacedObject must be called before GetReference is called on the new object");
-                }
-            }
+            if (self.GetReference(newObject, false) != null)
+                throw new ArgumentException(
+                    "RegisterReplacedObject must be called before GetReference is called on the new object");
 
-            refs.Add(new Entry()
-            {
-                Object = newObject,
-                Reference = oldObject
-            });
+            _obj2ref[newObject] = oldObject;
 
             return oldObject;
         }

--- a/Editor/API/ObjectRegistry.cs
+++ b/Editor/API/ObjectRegistry.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using nadena.dev.ndmf.rq;
 using nadena.dev.ndmf.runtime;
 using UnityEngine;
@@ -83,7 +84,13 @@ namespace nadena.dev.ndmf
         private readonly Dictionary<Object, ObjectReference> _obj2ref = new(new ObjectIdentityComparer<UnityObject>());
 
         internal readonly Transform AvatarRoot;
-        public static IObjectRegistry ActiveRegistry { get; internal set; }
+        private static readonly AsyncLocal<IObjectRegistry> _activeRegistry = new();
+
+        public static IObjectRegistry ActiveRegistry
+        {
+            get => _activeRegistry.Value;
+            set => _activeRegistry.Value = value;
+        }
         private readonly ObjectRegistry _parent;
 
         internal static ObjectRegistry Merge(Transform avatarRoot, IEnumerable<ObjectRegistry> inputs)

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -14,32 +14,6 @@ using UnityEngine;
 namespace nadena.dev.ndmf.preview
 {
     /// <summary>
-    ///     Various additional context data that is passed to render filters, which may or may not be helpful.
-    ///     Properties on this class have public setters for unit testing, but the instance that is passed to your code
-    ///     will throw if you attempt to change anything.
-    /// </summary>
-    [PublicAPI]
-    public sealed class RenderFilterContext
-    {
-        internal bool Sealed { get; set; }
-        private IObjectRegistry _objectRegistry;
-
-        /// <summary>
-        ///     An ObjectRegistry you should use to track objects that are replaced during the rendering process.
-        /// </summary>
-        /// <exception cref="InvalidOperationException"></exception>
-        public IObjectRegistry ObjectRegistry
-        {
-            get => _objectRegistry;
-            set
-            {
-                if (Sealed) throw new InvalidOperationException("RenderContext is sealed");
-                _objectRegistry = value;
-            }
-        }
-    }
-    
-    /// <summary>
     /// A group of renderers that will be processed together.
     /// </summary>
     [PublicAPI]
@@ -146,8 +120,7 @@ namespace nadena.dev.ndmf.preview
         public Task<IRenderFilterNode> Instantiate(
             RenderGroup group,
             IEnumerable<(Renderer, Renderer)> proxyPairs,
-            ComputeContext context,
-            RenderFilterContext renderFilterContext
+            ComputeContext context
         );
 
         // Allow for future expansion
@@ -219,7 +192,6 @@ namespace nadena.dev.ndmf.preview
         public Task<IRenderFilterNode> Refresh(
             IEnumerable<(Renderer, Renderer)> proxyPairs,
             ComputeContext context,
-            RenderFilterContext renderFilterContext,
             RenderAspects updatedAspects
         )
         {

--- a/Editor/PreviewSystem/Rendering/ProxyObjectCache.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyObjectCache.cs
@@ -74,7 +74,6 @@ namespace nadena.dev.ndmf.preview
                 return proxy;
             }
             
-            Debug.Log("=== Creating new proxy for " + original.gameObject.name);
             proxy = create();
             if (proxy == null)
             {

--- a/Editor/PreviewSystem/Rendering/ProxyObjectController.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyObjectController.cs
@@ -104,6 +104,8 @@ namespace nadena.dev.ndmf.preview
             foreach (var material in r.sharedMaterials)
             {
                 _monitorMaterials.Observe(material);
+                if (material == null) continue;
+                
                 var texPropIds = material.GetTexturePropertyNameIDs();
                 foreach (var texPropId in texPropIds)
                 {

--- a/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
@@ -133,7 +133,8 @@ namespace nadena.dev.ndmf.preview
                     {
                         if (nodeTasks.TryGetValue(r, out var task))
                         {
-                            return task.ContinueWith(task1 => (r, task1.Result.GetProxyFor(r)));
+                            return task.ContinueWith(task1 =>
+                                (r, task1.Result.GetProxyFor(r), task1.Result.ObjectRegistry));
                         }
                         else
                         {
@@ -149,8 +150,11 @@ namespace nadena.dev.ndmf.preview
                             OriginalToProxyRenderer = OriginalToProxyRenderer.Add(r, proxy.Renderer);
                             OriginalToProxyObject = OriginalToProxyObject.Add(r.gameObject, proxy.Renderer.gameObject);
                             ProxyToOriginalObject = ProxyToOriginalObject.Add(proxy.Renderer.gameObject, r.gameObject);
-                            
-                            return Task.FromResult((r, proxy));
+
+                            var registry = new ObjectRegistry(null);
+                            ((IObjectRegistry)registry).RegisterReplacedObject(r, proxy.Renderer);
+
+                            return Task.FromResult((r, proxy, registry));
                         }
                     });
 
@@ -163,7 +167,6 @@ namespace nadena.dev.ndmf.preview
                     var node = Task.WhenAll(resolved).ContinueWith(async items =>
                         {
                             var proxies = items.Result.ToList();
-                            var key = (group, filter);
 
                             if (priorNode != null)
                             {

--- a/UnitTests~/NodeControllerTest.cs
+++ b/UnitTests~/NodeControllerTest.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using nadena.dev.ndmf;
+using nadena.dev.ndmf.preview;
+using nadena.dev.ndmf.rq;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace UnitTests
+{
+    class TestRenderFilterNode : IRenderFilterNode
+    {
+        public RenderAspects WhatChanged { get; set; }
+
+        public Func<IEnumerable<(Renderer, Renderer)>, ComputeContext, RenderAspects, Task<IRenderFilterNode>> RefreshFunc { get; set; }
+        
+        public Task<IRenderFilterNode> Refresh(
+            IEnumerable<(Renderer, Renderer)> proxyPairs,
+            ComputeContext context,
+            RenderAspects updatedAspects
+        )
+        {
+            return RefreshFunc(proxyPairs, context, updatedAspects);
+        }
+    }
+
+    class TestRenderFilter : IRenderFilter
+    {
+        public ImmutableList<RenderGroup> GetTargetGroups(ComputeContext context)
+        {
+            throw new System.NotImplementedException();
+        }
+        
+        public Func<RenderGroup, IEnumerable<(Renderer, Renderer)>, ComputeContext, Task<IRenderFilterNode>> InstantiateFunc { get; set; }
+
+        public Task<IRenderFilterNode> Instantiate(RenderGroup group, IEnumerable<(Renderer, Renderer)> proxyPairs, ComputeContext context)
+        {
+            return InstantiateFunc(group, proxyPairs, context);
+        }
+    }
+    
+    public class NodeControllerTest : TestBase
+    {
+        private ProxyObjectCache _cache;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            _cache = new ProxyObjectCache();
+        }
+        
+        [TearDown]
+        public void TearDown()
+        {
+            _cache.Dispose();
+        }
+        
+        [Test]
+        public void TestObjectRegistryProcessing()
+        {
+            var filter = new TestRenderFilter();
+            var node = new TestRenderFilterNode();
+
+            var root = CreateRoot("r");
+            var c1 = CreateChild(root, "c1");
+            var c2 = CreateChild(root, "c2");
+            var tmp = CreateChild(root, "tmp");
+            
+            var r1 = c1.AddComponent<SkinnedMeshRenderer>();
+            var r2 = c2.AddComponent<SkinnedMeshRenderer>();
+
+            var poc1 = new ProxyObjectController(_cache, r1, null);
+            var poc2 = new ProxyObjectController(_cache, r2, null);
+            
+            var group = new RenderGroup(ImmutableList.Create<Renderer>(r1, r2));
+
+            var or1 = new ObjectRegistry(null);
+            var or2 = new ObjectRegistry(null);
+
+            ((IObjectRegistry)or1).RegisterReplacedObject(c1, r1);
+            ((IObjectRegistry)or2).RegisterReplacedObject(c2, r2);
+
+            filter.InstantiateFunc = (_, _, _) =>
+            {
+                Assert.AreEqual(ObjectRegistry.GetReference(c1), ObjectRegistry.GetReference(r1));
+                Assert.AreEqual(ObjectRegistry.GetReference(c2), ObjectRegistry.GetReference(r2));
+
+                ObjectRegistry.RegisterReplacedObject(root, tmp);
+                
+                return Task.FromResult<IRenderFilterNode>(node);
+            };
+            
+            var nodeController = NodeController.Create(
+                filter,
+                group,
+                new()
+                {
+                    (r1, poc1, or1),
+                    (r2, poc2, or2)
+                }
+            ).Result;
+
+            IObjectRegistry reg2 = nodeController.ObjectRegistry;
+            Assert.AreEqual(reg2.GetReference(root), reg2.GetReference(tmp));
+            
+            Assert.AreNotEqual(((IObjectRegistry)or1).GetReference(root), ((IObjectRegistry)or2).GetReference(tmp));
+            
+            poc1.Dispose();
+            poc2.Dispose();
+        }
+    }
+}

--- a/UnitTests~/NodeControllerTest.cs.meta
+++ b/UnitTests~/NodeControllerTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3d90fbe7d711413087e7a762fd31a799
+timeCreated: 1720495208


### PR DESCRIPTION
Not sure I 100% like the idea of passing multiple context objects to these methods, but I also don't want to rely on `AsyncLocal` or similar for this...