### PR TITLE
fix: Scene visibility states is not copy to proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#327] Z-fighting occurs in prefab isolation view
 - [#328] Fix issue where preview system is not reinitialized after a scene change
 - [#329] Fix issue where scene root monitoring breaks after a domain reload
+- [#334] Fix objects under preview not respecting scene visibility state
 
 ### Changed
 

--- a/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
@@ -1,4 +1,4 @@
-﻿#region
+#region
 
 using System;
 using System.Collections.Generic;
@@ -274,6 +274,31 @@ namespace nadena.dev.ndmf.preview
         {
             if (!IsReady) return;
             
+            var manager = SceneVisibilityManager.instance;
+            foreach (var pair in _proxies)
+            {
+                var originalRenderer = pair.Key;
+                var proxyRenderer = pair.Value.Renderer;
+                if (originalRenderer == null || proxyRenderer == null) { continue; }
+                var originalObject = originalRenderer.gameObject;
+                var proxyObject = proxyRenderer.gameObject;
+
+                var isOriginHidden = manager.IsHidden(originalObject, true);
+                var needHiddenStateChange = isOriginHidden != manager.IsHidden(proxyObject, true);
+                if (needHiddenStateChange)
+                {
+                    if (isOriginHidden) manager.Hide(proxyObject, true);
+                    else manager.Show(proxyObject, true);
+                }
+
+                var isOriginPickingDisabled = manager.IsPickingDisabled(originalObject, true);
+                var needPickableStateChange = isOriginPickingDisabled != manager.IsPickingDisabled(proxyObject, true);
+                if (needPickableStateChange)
+                {
+                    if (isOriginPickingDisabled) manager.DisablePicking(proxyObject, true);
+                    else manager.EnablePicking(proxyObject, true);
+                }
+            }
             foreach (var pair in _proxies)
             {
                 pair.Value.OnPreFrame();


### PR DESCRIPTION
Close #323, https://github.com/ReinaS-64892/TexTransTool/issues/606, https://github.com/bdunderscore/modular-avatar/issues/971

SceneVisibilityManager からとれる状態をプロキシーのコピーするようにしました！
ただ...実装とか呼ぶ場所とかがもっといいものがあれば教えてほしいです！