### PR TITLE
feat: skip preview on most scene cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#330] Preview objects are now hidden by placing them in a hidden subscene, instead of harmony patching the hierarchy.
   This should improve stability in general.
+- [#335] Skip preview rendering on all cameras except the scene view camera and the VRCSDK thumbnail camera. 
 
 ### Removed
 

--- a/Editor/PreviewSystem/ProxyManager.cs
+++ b/Editor/PreviewSystem/ProxyManager.cs
@@ -25,6 +25,14 @@ namespace nadena.dev.ndmf.preview
 
         private static List<(Renderer, bool)> _resetActions = new();
 
+        private static bool ShouldHookCamera(Camera cam)
+        {
+            if (cam.name == "SceneCamera" && cam.gameObject.hideFlags == HideFlags.HideAndDontSave) return true;
+            if (cam.name == "TempCamera" && cam.targetTexture?.name == "ThumbnailCapture") return true;
+
+            return false;
+        }
+
         private static void OnPostRender(Camera cam)
         {
             ResetStates();
@@ -33,6 +41,8 @@ namespace nadena.dev.ndmf.preview
         private static void OnPreCull(Camera cam)
         {
             ResetStates();
+
+            if (!ShouldHookCamera(cam)) return;
 
             if (EditorApplication.isPlayingOrWillChangePlaymode) return;
 


### PR DESCRIPTION
This avoids O(n^2) preview costs when avatars have cameras attached.

Closes: #331
