### PR TITLE
chore: don't disable sub-options when a preview plugin is disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#330] Preview objects are now hidden by placing them in a hidden subscene, instead of harmony patching the hierarchy.
   This should improve stability in general.
 - [#335] Skip preview rendering on all cameras except the scene view camera and the VRCSDK thumbnail camera. 
+- [#338] Don't disable sub-options when a preview plugin is disabled.
 
 ### Removed
 

--- a/Editor/PreviewSystem/UI/PreviewPrefsUI.cs
+++ b/Editor/PreviewSystem/UI/PreviewPrefsUI.cs
@@ -215,10 +215,6 @@ namespace nadena.dev.ndmf.preview.UI
                 _isPass = itemData.IsPass;
                 _qualifiedName = itemData.QualifiedName;
 
-                var isEnabled = !itemData.IsPass ||
-                                PreviewPrefs.instance.IsPreviewPluginEnabled(itemData.PluginQualifiedName);
-                _toggle.SetEnabled(isEnabled);
-
                 if (itemData.IsPass)
                     _toggle.AddToClassList("ndmf-pass-item");
                 else


### PR DESCRIPTION
Closes: #314
