### PR TITLE
fix: Listening to visibility change event that are too large.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#355] Excessive invalidation when scene view visibility states change
+
 ### Changed
 
 ### Removed

--- a/Editor/PreviewSystem/Rendering/TargetSet.cs
+++ b/Editor/PreviewSystem/Rendering/TargetSet.cs
@@ -78,12 +78,11 @@ namespace nadena.dev.ndmf.preview
             Profiler.BeginSample("TargetSet.ResolveActiveStages");
             _targetSetContext.Invalidates(context);
 
-            foreach (var renderer in _stages.SelectMany(s => s.Groups).SelectMany(g => g.Renderers))
-            {
-                var nowVisibleState = SceneVisibilityManager.instance.IsHidden(renderer.gameObject, true);
-                cs.ListenerSet<bool>.Filter filter = _ => { return nowVisibleState != SceneVisibilityManager.instance.IsHidden(renderer.gameObject, true); };
-                VisibilityMonitor.OnVisibilityChange.Register(filter, context);
-            }
+            var targetRenderers = _stages
+                .SelectMany(s => s.Groups)
+                .SelectMany(g => g.Renderers)
+                .Select(r => (r, SceneVisibilityManager.instance.IsHidden(r.gameObject, true))).ToArray();
+            VisibilityMonitor.OnVisibilityChange.Register(_ => targetRenderers.Any(rp => rp.Item2 != SceneVisibilityManager.instance.IsHidden(rp.r.gameObject, true)), context);
 
             HashSet<Renderer> maybeActiveRenderers = new HashSet<Renderer>(new ObjectIdentityComparer<Renderer>());
             

--- a/Editor/PreviewSystem/Rendering/TargetSet.cs
+++ b/Editor/PreviewSystem/Rendering/TargetSet.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.Profiling;
 
@@ -76,7 +77,13 @@ namespace nadena.dev.ndmf.preview
         {
             Profiler.BeginSample("TargetSet.ResolveActiveStages");
             _targetSetContext.Invalidates(context);
-            VisibilityMonitor.OnVisibilityChange.Register(_ => true, context);
+
+            foreach (var renderer in _stages.SelectMany(s => s.Groups).SelectMany(g => g.Renderers))
+            {
+                var nowVisibleState = SceneVisibilityManager.instance.IsHidden(renderer.gameObject, true);
+                cs.ListenerSet<bool>.Filter filter = _ => { return nowVisibleState != SceneVisibilityManager.instance.IsHidden(renderer.gameObject, true); };
+                VisibilityMonitor.OnVisibilityChange.Register(filter, context);
+            }
 
             HashSet<Renderer> maybeActiveRenderers = new HashSet<Renderer>(new ObjectIdentityComparer<Renderer>());
             

--- a/Editor/PreviewSystem/Rendering/VisibilityMonitor.cs
+++ b/Editor/PreviewSystem/Rendering/VisibilityMonitor.cs
@@ -1,4 +1,4 @@
-﻿using nadena.dev.ndmf.cs;
+using nadena.dev.ndmf.cs;
 using UnityEditor;
 
 namespace nadena.dev.ndmf.preview
@@ -14,7 +14,7 @@ namespace nadena.dev.ndmf.preview
         {
             SceneVisibilityManager.visibilityChanged += () =>
             {
-                OnVisibilityChange.FireAll();
+                OnVisibilityChange.Fire(true);
                 
                 Sequence++;
             };


### PR DESCRIPTION
Invalidate をたくさん回していこうという方針でも、 アバターに全く無関係なオブジェクトや一時的なオブジェクトの影響を受けるのはやりすぎだと思います！

そんなわけで #352 の修正です。
具体的な内容は ListenerSet.Filter を用いて、プレビュー対象のレンダラーだけを監視、変更されたことを確認してから Invalidates させるようにしています！