### PR TITLE
fix: prevent creation of overlapping render groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#355] Excessive invalidation when scene view visibility states change
 
 ### Changed
+- [#364] Prevent creation of overlapping render groups in the same `IRenderFilter`
 
 ### Removed
 

--- a/Editor/PreviewSystem/Rendering/TargetSet.cs
+++ b/Editor/PreviewSystem/Rendering/TargetSet.cs
@@ -39,6 +39,17 @@ namespace nadena.dev.ndmf.preview
                     Profiler.BeginSample("TargetSet.GetTargetGroups[" + filter + "]");
                     var groups = filter.GetTargetGroups(_targetSetContext);
                     if (groups.IsEmpty) continue;
+
+                    var duplicateRenderers = groups.SelectMany(g => g.Renderers)
+                        .GroupBy(r => r)
+                        .FirstOrDefault(agg => agg.Count() > 1);
+                    if (duplicateRenderers != null)
+                    {
+                        Debug.LogError("[" + filter + "] Duplicate renderer " + duplicateRenderers.Key +
+                                       " in groups: " + string.Join(", ", groups));
+                        // Suppress this filter
+                        continue;
+                    }
                     
                     builder.Add(new Stage
                     {


### PR DESCRIPTION
This generally is unintended and can result in horrible performance issues, so block it entirely.
