### PR TITLE
fix: Refresh->Create no longer inherits object replacements from prior node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#362] Fixed unclosed profiler scope in TargetSet
 - [#355] Excessive invalidation when scene view visibility states change
 - [#363] Reduce GC pressure caused by `ComputeContext.GetComponent`
+- [#367] When `IRenderFilter.Create` is invoked when refreshing a filter node, it would get an `ObjectRegistry`
+  containing items registered in the prior generation of the node.
 
 ### Changed
 - [#364] Prevent creation of overlapping render groups in the same `IRenderFilter`

--- a/Editor/PreviewSystem/Rendering/NodeController.cs
+++ b/Editor/PreviewSystem/Rendering/NodeController.cs
@@ -96,7 +96,7 @@ namespace nadena.dev.ndmf.preview
             return Create(filter, group, ObjectRegistry.Merge(null, proxies.Select(p => p.Item3)), proxies, trace);
         }
 
-        public static async Task<NodeController> Create(
+        private static async Task<NodeController> Create(
             IRenderFilter filter,
             RenderGroup group,
             ObjectRegistry registry,
@@ -184,6 +184,9 @@ namespace nadena.dev.ndmf.preview
             }
             else if (node == null)
             {
+                // rebuild registry so we forget any garbage left by the aborted Refresh call
+                registry = ObjectRegistry.Merge(null, proxies.Select(p => p.Item3));
+                
                 return await Create(_filter, _group, registry, proxies, trace);
             }
             else


### PR DESCRIPTION
Previously, when we invoked Refresh and got a null back, we'd pass an ObjectRegistry which contains any replacements
registered in the prior Create/Refresh call to Create. This broke things in #358 where (presumably) the Create
implementation was reasonably assuming that it got a fresh ObjectRegistry.

Fixes: #358
