### PR TITLE
fix: TargetSet is invalidated every frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+
+- [#372] Fix an issue where the preview pipeline would be rebuilt every editor frame
 - [#369] Fix a `NullReferenceException` generated when previewed renderers are destroyed
 
 ### Changed

--- a/Editor/PreviewSystem/Rendering/TargetSet.cs
+++ b/Editor/PreviewSystem/Rendering/TargetSet.cs
@@ -82,7 +82,7 @@ namespace nadena.dev.ndmf.preview
             if (renderer == null) return false;
             if (!context.ActiveInHierarchy(renderer.gameObject)) return false;
 
-            return context.Observe(renderer, r => r.enabled && !r.forceRenderingOff);
+            return context.Observe(renderer, r => r.enabled);
         }
         
         public ImmutableList<Stage> ResolveActiveStages(ComputeContext context)


### PR DESCRIPTION
Partially addresses #357; this still deserves a larger refactor to address
the issue that replacing proxies on pipeline rebuild can break picking,
but this should make the problem sufficiently rare for now.
