### PR TITLE
fix: NRE thrown if source renderer is destroyed during preview processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#372] Fix an issue where the preview pipeline would be rebuilt every editor frame
 - [#369] Fix a `NullReferenceException` generated when previewed renderers are destroyed
 - [#371] Performance improvements in change monitoring
+- [#374] Suppress processing of renderers deleted during pipeline processing
 
 ### Changed
 

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -86,6 +86,13 @@ namespace nadena.dev.ndmf.preview
         {
             return "RenderGroup(" + string.Join(", ", Renderers.Select(r => r.name)) + ")";
         }
+
+        internal virtual RenderGroup FilterLive()
+        {
+            if (Renderers.All(r => r != null)) return this;
+
+            return new RenderGroup(Renderers.Where(r => r != null).ToImmutableList());
+        }
     }
 
     internal sealed class RenderGroup<T> : RenderGroup
@@ -127,6 +134,13 @@ namespace nadena.dev.ndmf.preview
             }
             
             return HashCode.Combine(base.GetHashCode(), EqualityComparer<T>.Default.GetHashCode(Context));
+        }
+
+        internal override RenderGroup FilterLive()
+        {
+            if (Renderers.All(r => r != null)) return this;
+
+            return new RenderGroup<T>(Renderers.Where(r => r != null).ToImmutableList(), Context);
         }
     }
 

--- a/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
@@ -152,8 +152,9 @@ namespace nadena.dev.ndmf.preview
                 }
 
                 int groupIndex = -1;
-                foreach (var group in stage.Originals.OrderBy(g => g.GetHashCode()))
+                foreach (var group_raw in stage.Originals.OrderBy(g => g.GetHashCode()))
                 {
+                    var group = group_raw.FilterLive();
                     total_nodes++;
                     
                     groupIndex++;


### PR DESCRIPTION
Reported in https://github.com/bdunderscore/modular-avatar/issues/1055
