### PR TITLE
fix: suppress IRenderFilter with unsupported renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Workaround [VRCSDK bug](https://feedback.vrchat.com/sdk-bug-reports/p/string-conversion-errors-from-runtimeassemblygetcodebase-with-japanese-locale-an)
   caused by non-ASCII project paths.
 - [#388] Improve handling for renderers which are destroyed during preview pipeline construction
+- [#390] Suppress IRenderFilter with unsupported renderers
 
 ### Changed
 

--- a/Editor/PreviewSystem/Rendering/TargetSet.cs
+++ b/Editor/PreviewSystem/Rendering/TargetSet.cs
@@ -41,6 +41,16 @@ namespace nadena.dev.ndmf.preview
                     Profiler.EndSample();
                     if (groups.IsEmpty) continue;
 
+                    var unsupportedRenderer = groups.SelectMany(g => g.Renderers)
+                        .FirstOrDefault(x => x is not MeshRenderer and not SkinnedMeshRenderer);
+                    if (unsupportedRenderer != null)
+                    {
+                        Debug.LogError("[" + filter + "] Unsupported renderer " + unsupportedRenderer +
+                                       " in groups: " + string.Join(", ", groups));
+                        // Suppress this filter
+                        continue;
+                    }
+
                     var duplicateRenderers = groups.SelectMany(g => g.Renderers)
                         .GroupBy(r => r)
                         .FirstOrDefault(agg => agg.Count() > 1);


### PR DESCRIPTION
Closes #387 です。

IRenderFilter ごと無視するのではなく、サポートされない Renderer だけ除外する方がよければそうします。
(その場合、すぐ下にある重複チェックでもそうします…？)