### PR TITLE
fix: Refresh preview when existing scene was opened

### DIFF
--- a/Editor/PreviewSystem/NDMFPreview.cs
+++ b/Editor/PreviewSystem/NDMFPreview.cs
@@ -45,6 +45,11 @@ namespace nadena.dev.ndmf.preview
                         break;
                 }
             };
+            
+            EditorSceneManager.sceneOpened += (_, _) =>
+            {
+                SetPreviewState();
+            };
         }
 
         private static int _disablePreviewDepth;


### PR DESCRIPTION
Closes #392 

手元の方で勝手に修正したのでPR投げてみましたが、
- 更新のやり方があってるか自信がない
- `EditorSceneManager.sceneOpened` のタイミングで合ってるかは分からない
- `___NDMF Preview___` に反応してしまう（ので、どうにかした方がいいとは思った）

等々な感じなので確認の程何卒よろしくお願いします・・・ :pray: