### PR TITLE
feat: ability to allow type mismatch between ProvidedParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [#407] Added `ProvidedParameter.AllowTypeMismatch` to resolve parameter type mismatch automatically
 
 ### Fixed
 

--- a/Editor/VRChat/ParameterIntrospection/IParameterProvider.cs
+++ b/Editor/VRChat/ParameterIntrospection/IParameterProvider.cs
@@ -59,6 +59,7 @@ namespace nadena.dev.ndmf
                    Equals(Source, other.Source) &&
                    Equals(Plugin, other.Plugin) &&
                    ParameterType == other.ParameterType &&
+                   AllowTypeMismatch == other.AllowTypeMismatch &&
                    IsHidden == other.IsHidden &&
                    WantSynced == other.WantSynced;
         }
@@ -79,6 +80,7 @@ namespace nadena.dev.ndmf
                 hashCode = (hashCode * 397) ^ (Source != null ? Source.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (Plugin != null ? Plugin.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ ParameterType.GetHashCode();
+                hashCode = (hashCode * 397) ^ AllowTypeMismatch.GetHashCode();
                 hashCode = (hashCode * 397) ^ IsHidden.GetHashCode();
                 hashCode = (hashCode * 397) ^ WantSynced.GetHashCode();
                 return hashCode;
@@ -157,6 +159,11 @@ namespace nadena.dev.ndmf
         /// (e.g. with contact receivers).
         /// </summary>
         public AnimatorControllerParameterType? ParameterType { get; set; }
+
+        /// <summary>
+        /// If true, mismatched parameter types will be merged automatically
+        /// </summary>
+        public bool AllowTypeMismatch { get; set; }
 
         /// <summary>
         /// If true, this parameter will not be registered in the VRC Expressions Parameters asset. Forced to true for

--- a/Editor/VRChat/ParameterIntrospection/IParameterProvider.cs
+++ b/Editor/VRChat/ParameterIntrospection/IParameterProvider.cs
@@ -59,7 +59,7 @@ namespace nadena.dev.ndmf
                    Equals(Source, other.Source) &&
                    Equals(Plugin, other.Plugin) &&
                    ParameterType == other.ParameterType &&
-                   AllowTypeMismatch == other.AllowTypeMismatch &&
+                   ExpandTypeOnConflict == other.ExpandTypeOnConflict &&
                    IsHidden == other.IsHidden &&
                    WantSynced == other.WantSynced;
         }
@@ -80,7 +80,7 @@ namespace nadena.dev.ndmf
                 hashCode = (hashCode * 397) ^ (Source != null ? Source.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (Plugin != null ? Plugin.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ ParameterType.GetHashCode();
-                hashCode = (hashCode * 397) ^ AllowTypeMismatch.GetHashCode();
+                hashCode = (hashCode * 397) ^ ExpandTypeOnConflict.GetHashCode();
                 hashCode = (hashCode * 397) ^ IsHidden.GetHashCode();
                 hashCode = (hashCode * 397) ^ WantSynced.GetHashCode();
                 return hashCode;
@@ -161,9 +161,9 @@ namespace nadena.dev.ndmf
         public AnimatorControllerParameterType? ParameterType { get; set; }
 
         /// <summary>
-        /// If true, mismatched parameter types will be merged automatically
+        /// If true, conflicting parameter types will be expanded to Bool --> Int --> Float.
         /// </summary>
-        public bool AllowTypeMismatch { get; set; }
+        public bool ExpandTypeOnConflict { get; set; }
 
         /// <summary>
         /// If true, this parameter will not be registered in the VRC Expressions Parameters asset. Forced to true for

--- a/Editor/VRChat/ParameterIntrospection/ParameterInfo.cs
+++ b/Editor/VRChat/ParameterIntrospection/ParameterInfo.cs
@@ -191,7 +191,7 @@ namespace nadena.dev.ndmf
 
                     if (parameters.TryGetValue(newParameter.NamePair, out var existingParam))
                     {
-                        ResolveConflict(onConflict, existingParam, newParameter, false);
+                        ResolveConflict(existingParam.Parameter, newParameter, onConflict);
                     }
                     else
                     {
@@ -210,7 +210,7 @@ namespace nadena.dev.ndmf
             {
                 if (parameters.TryGetValue(kvp.Key, out var existingParam))
                 {
-                    ResolveConflict(onConflict, existingParam, kvp.Value.Parameter, true);
+                    ResolveConflict(existingParam.Parameter, kvp.Value.Parameter, onConflict);
                 }
                 else
                 {
@@ -239,7 +239,7 @@ namespace nadena.dev.ndmf
                 {
                     if (parameters.TryGetValue(rp.Parameter.NamePair, out var existingParam))
                     {
-                        ResolveConflict(onConflict, existingParam, rp.Parameter, false);
+                        ResolveConflict(existingParam.Parameter, rp.Parameter, onConflict);
                     }
                     else
                     {
@@ -251,36 +251,45 @@ namespace nadena.dev.ndmf
             return parameters;
         }
 
-        private void ResolveConflict(ConflictHandler onConflict, RegisteredParameter oldP, ProvidedParameter newP,
-            bool isParentChild)
+        private void ResolveConflict(ProvidedParameter oldP, ProvidedParameter newP, ConflictHandler onConflict)
         {
-            if (oldP.Parameter.ParameterType != newP.ParameterType)
+            ResolveParameterType(oldP, newP, onConflict);
+
+            oldP.IsAnimatorOnly &= newP.IsAnimatorOnly;
+            oldP.IsHidden &= newP.IsHidden;
+            oldP.WantSynced |= newP.WantSynced;
+            oldP.DefaultValue ??= newP.DefaultValue;
+        }
+
+        private void ResolveParameterType(ProvidedParameter oldP, ProvidedParameter newP, ConflictHandler onConflict)
+        {
+            if (oldP.ParameterType == newP.ParameterType ||
+                oldP.ParameterType != null && newP.ParameterType == null ||
+                oldP.ParameterType != null && newP.IsAnimatorOnly)
             {
-                if ((oldP.Parameter.ParameterType == null) != (newP.ParameterType == null))
-                {
-                    oldP.Parameter.ParameterType = oldP.Parameter.ParameterType ?? newP.ParameterType;
-                }
-                else if (oldP.Parameter.IsAnimatorOnly && newP.IsAnimatorOnly)
-                {
-                    // ignore the conflict; we'll resolve everything to float in the animator if needed
-                }
-                else if (!oldP.Parameter.IsAnimatorOnly && !newP.IsAnimatorOnly)
-                {
-                    // Flag conflict and resolve to oldP's parameter type
-                    onConflict(ConflictType.TypeMismatch, oldP.Parameter, newP);
-                }
-                else if (!newP.IsAnimatorOnly)
-                {
-                    // Update type to match the non-animator-only value in newP
-                    oldP.Parameter.ParameterType = newP.ParameterType;
-                }
+                return;
             }
 
-            oldP.Parameter.IsAnimatorOnly &= newP.IsAnimatorOnly;
-            oldP.Parameter.IsHidden &= newP.IsHidden;
-            oldP.Parameter.WantSynced = oldP.Parameter.WantSynced || newP.WantSynced;
+            if (oldP.ParameterType == null ||
+                oldP.IsAnimatorOnly)
+            {
+                oldP.ParameterType = newP.ParameterType;
+                return;
+            }
 
-            oldP.Parameter.DefaultValue ??= newP.DefaultValue;
+            if (!oldP.AllowTypeMismatch ||
+                !newP.AllowTypeMismatch)
+            {
+                onConflict(ConflictType.TypeMismatch, oldP, newP);
+                return;
+            }
+
+            if (oldP.ParameterType == AnimatorControllerParameterType.Bool ||
+                newP.ParameterType == AnimatorControllerParameterType.Float)
+            {
+                oldP.ParameterType = newP.ParameterType;
+                return;
+            }
         }
     }
 }

--- a/Editor/VRChat/ParameterIntrospection/ParameterInfo.cs
+++ b/Editor/VRChat/ParameterIntrospection/ParameterInfo.cs
@@ -263,9 +263,9 @@ namespace nadena.dev.ndmf
 
         private void ResolveParameterType(ProvidedParameter oldP, ProvidedParameter newP, ConflictHandler onConflict)
         {
-            if (oldP.ParameterType == newP.ParameterType ||
-                oldP.ParameterType != null && newP.ParameterType == null ||
-                oldP.ParameterType != null && newP.IsAnimatorOnly)
+            if ((oldP.ParameterType == newP.ParameterType) ||
+                (oldP.ParameterType != null && newP.ParameterType == null) ||
+                (oldP.ParameterType != null && newP.IsAnimatorOnly))
             {
                 return;
             }
@@ -277,8 +277,8 @@ namespace nadena.dev.ndmf
                 return;
             }
 
-            if (!oldP.AllowTypeMismatch ||
-                !newP.AllowTypeMismatch)
+            if (!oldP.ExpandTypeOnConflict ||
+                !newP.ExpandTypeOnConflict)
             {
                 onConflict(ConflictType.TypeMismatch, oldP, newP);
                 return;

--- a/UnitTests~/ParameterIntrospection/ParameterIntrospectionTest.cs
+++ b/UnitTests~/ParameterIntrospection/ParameterIntrospectionTest.cs
@@ -175,13 +175,59 @@ namespace UnitTests.Parameters
             (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Bool, AnimatorControllerParameterType.Float, true, true);
             Assert.AreEqual(0, conflicts.Count);
             Assert.AreEqual(AnimatorControllerParameterType.Bool, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Bool, AnimatorControllerParameterType.Float, false, false, true);
+            Assert.AreEqual(1, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Bool, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Bool, AnimatorControllerParameterType.Float, false, false, false, true);
+            Assert.AreEqual(1, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Bool, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Bool, AnimatorControllerParameterType.Int, false, false, true, true);
+            Assert.AreEqual(0, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Int, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Bool, AnimatorControllerParameterType.Float, false, false, true, true);
+            Assert.AreEqual(0, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Float, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Int, AnimatorControllerParameterType.Bool, false, false, true, true);
+            Assert.AreEqual(0, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Int, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Int, AnimatorControllerParameterType.Float, false, false, true, true);
+            Assert.AreEqual(0, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Float, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Float, AnimatorControllerParameterType.Bool, false, false, true, true);
+            Assert.AreEqual(0, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Float, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Float, AnimatorControllerParameterType.Int, false, false, true, true);
+            Assert.AreEqual(0, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Float, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Bool, AnimatorControllerParameterType.Float, true, false, true, true);
+            Assert.AreEqual(0, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Float, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Bool, AnimatorControllerParameterType.Float, false, true, true, true);
+            Assert.AreEqual(0, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Bool, outParam.ParameterType);
+
+            (outParam, conflicts) = TypeMerge(AnimatorControllerParameterType.Bool, AnimatorControllerParameterType.Float, true, true, true, true);
+            Assert.AreEqual(0, conflicts.Count);
+            Assert.AreEqual(AnimatorControllerParameterType.Bool, outParam.ParameterType);
         }
 
         (ProvidedParameter, List<ParameterInfo.ConflictType>) TypeMerge(
             AnimatorControllerParameterType? ty1,
             AnimatorControllerParameterType? ty2,
             bool animOnly1 = false,
-            bool animOnly2 = false
+            bool animOnly2 = false,
+            bool allowMismatch1 = false,
+            bool allowMismatch2 = false
         )
         {
             var av = CreateRoot("avatar");
@@ -197,8 +243,10 @@ namespace UnitTests.Parameters
             
             var p1 = new ProvidedParameter("p1", ParameterNamespace.Animator, t1, InternalPasses.Instance, ty1);
             p1.IsAnimatorOnly = animOnly1;
+            p1.AllowTypeMismatch = allowMismatch1;
             var p2 = new ProvidedParameter("p1", ParameterNamespace.Animator, t2, InternalPasses.Instance, ty2);
             p2.IsAnimatorOnly = animOnly2;
+            p2.AllowTypeMismatch = allowMismatch2;
             
             ParamTestComponentProvider.SetParameters(t1, p1);
             ParamTestComponentProvider.SetParameters(t2, p2);

--- a/UnitTests~/ParameterIntrospection/ParameterIntrospectionTest.cs
+++ b/UnitTests~/ParameterIntrospection/ParameterIntrospectionTest.cs
@@ -243,10 +243,10 @@ namespace UnitTests.Parameters
             
             var p1 = new ProvidedParameter("p1", ParameterNamespace.Animator, t1, InternalPasses.Instance, ty1);
             p1.IsAnimatorOnly = animOnly1;
-            p1.AllowTypeMismatch = allowMismatch1;
+            p1.ExpandTypeOnConflict = allowMismatch1;
             var p2 = new ProvidedParameter("p1", ParameterNamespace.Animator, t2, InternalPasses.Instance, ty2);
             p2.IsAnimatorOnly = animOnly2;
-            p2.AllowTypeMismatch = allowMismatch2;
+            p2.ExpandTypeOnConflict = allowMismatch2;
             
             ParamTestComponentProvider.SetParameters(t1, p1);
             ParamTestComponentProvider.SetParameters(t2, p2);


### PR DESCRIPTION
`ProvidedParameter` をマージする際、`ParameterType` が違ったら互いの `ParameterType` を見て自動的に解決するかどうかを指定できるようにします。

こちらで使用する機能です。
https://github.com/bdunderscore/modular-avatar/pull/1174#discussion_r1766104325