### PR TITLE
fix: serialize assets after the initial plugin hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#408] Improved performance of `BuildContext.Serialize`
 
 ### Changed
+- [#408] Unserialized assets will be serialized after the Transforming phase completes (before e.g. VRCFury runs)
 
 ### Removed
 

--- a/Editor/API/BuildContext.cs
+++ b/Editor/API/BuildContext.cs
@@ -213,6 +213,8 @@ namespace nadena.dev.ndmf
                 return; // unit tests with no serialized assets
             }
 
+            Profiler.BeginSample("BuildContext.Serialize");
+            
             HashSet<UnityObject> _savedObjects =
                 new HashSet<UnityObject>(AssetDatabase.LoadAllAssetsAtPath(AssetDatabase.GetAssetPath(AssetContainer)));
 
@@ -280,6 +282,8 @@ namespace nadena.dev.ndmf
 
                 UnityEngine.Object.DestroyImmediate(asset);
             }
+            
+            Profiler.EndSample();
         }
 
         public void DeactivateExtensionContext<T>() where T : IExtensionContext

--- a/Editor/VRChat/BuildFrameworkPreprocessHook.cs
+++ b/Editor/VRChat/BuildFrameworkPreprocessHook.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using nadena.dev.ndmf.runtime;
+using UnityEditor;
 using UnityEngine;
 using VRC.SDKBase.Editor.BuildPipeline;
 using Debug = UnityEngine.Debug;
@@ -41,6 +42,8 @@ namespace nadena.dev.ndmf.VRChat
                 holder.context = new BuildContext(avatarGameObject, AvatarProcessor.TemporaryAssetRoot);
 
                 AvatarProcessor.ProcessAvatar(holder.context, BuildPhase.Resolving, BuildPhase.Transforming);
+                holder.context.Serialize();
+
                 return true;
             }
             catch (Exception e)


### PR DESCRIPTION
This ensures that we don't have any references from assets to non-assets when passing control to non-NDMF hooks such as VRCF.

As a part of this, also optimize the `BuildContext.Serialize` processing so it doesn't take 8s on Mizuki...