### PR TITLE
fix: ProxyPipeline invalidations do not trigger a redraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#414] ProxyPipeline invalidations don't trigger a redraw in some cases
 
 ### Changed
 

--- a/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
@@ -107,6 +107,11 @@ namespace nadena.dev.ndmf.preview
             }
         }
 
+        private static void OnInvalidateRedraw(ProxyPipeline obj)
+        {
+            RepaintTrigger.RequestRepaint();
+        }
+
         private async Task Build(ProxyObjectCache proxyCache, IEnumerable<IRenderFilter> filters,
             ProxyPipeline priorPipeline)
         {
@@ -115,6 +120,8 @@ namespace nadena.dev.ndmf.preview
             Profiler.BeginSample("ProxyPipeline.Build.Synchronous");
             var context = new ComputeContext($"ProxyPipeline {_generation}");
             _ctx = context; // prevent GC
+            
+            _ctx.InvokeOnInvalidate(this, OnInvalidateRedraw);
 
 #if NDMF_DEBUG
             Debug.WriteLine($"Building pipeline {_generation}");


### PR DESCRIPTION
Closes: https://github.com/bdunderscore/modular-avatar/issues/1201
