### PR TITLE
fix: preview state breaks when proxy renderer is destroyed unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#417] Automatically recover when proxy renderers are destroyed unexpectedly
 
 ### Changed
 

--- a/Editor/PreviewSystem/Rendering/ProxyObjectController.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyObjectController.cs
@@ -131,6 +131,10 @@ namespace nadena.dev.ndmf.preview
         {
             if (_replacementRenderer == null || _originalRenderer == null)
             {
+                if (_replacementRenderer == null)
+                {
+                    Debug.LogWarning("Proxy object was destroyed improperly! Resetting pipeline...");
+                }
                 return false;
             }
 


### PR DESCRIPTION
This adds logic to automatically recover the proxy pipeline if proxy renderers
are destroyed for whatever reason.

Related: https://github.com/bdunderscore/modular-avatar/issues/1177
