### PR TITLE
fix: recreated nodes don't trigger downstream refresh calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#425] PublishedValue changes now immediately trigger repaint
 - [#428] Preview trace window copy button doesn't work
+- [#429] Downstream nodes are not refreshed after recreating a node
 
 ### Changed
 

--- a/Editor/PreviewSystem/Rendering/NodeController.cs
+++ b/Editor/PreviewSystem/Rendering/NodeController.cs
@@ -208,10 +208,7 @@ namespace nadena.dev.ndmf.preview
                 }
                 else if (node == null)
                 {
-                    // rebuild registry so we forget any garbage left by the aborted Refresh call
-                    registry = ObjectRegistry.Merge(null, proxies.Select(p => p.Item3));
-
-                    return await Create(_filter, _group, registry, proxies, trace);
+                    return null;
                 }
                 else
                 {


### PR DESCRIPTION
Closes: #322
