### PR TITLE
fix: File -> Save As breaks in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#435] Fixed an issue where `File -> Save As` could break due to the internal preview scene becoming selected
 
 ### Changed
 

--- a/Editor/PreviewSystem/Rendering/NDMFPreviewSceneManager.cs
+++ b/Editor/PreviewSystem/Rendering/NDMFPreviewSceneManager.cs
@@ -52,6 +52,31 @@ namespace nadena.dev.ndmf.preview
                     // We never want to save anything in the preview scene, and we definitely don't want to end up with
                     // UI popups prompting to save it, so aggressively clear its dirty flag.
                     clearSceneDirtiness?.Invoke(null, new object[] { _previewScene });
+
+                if (_previewScene.IsValid() && SceneManager.GetActiveScene() == _previewScene)
+                {
+                    // Oops, make sure the preview scene isn't selected
+                    var found = false;
+
+                    var sceneCount = SceneManager.sceneCount;
+                    for (var i = 0; i < sceneCount; i++)
+                    {
+                        var scene = SceneManager.GetSceneAt(i);
+                        if (scene == _previewScene) continue;
+
+                        SceneManager.SetActiveScene(scene);
+                        found = true;
+                        break;
+                    }
+
+                    if (!found)
+                    {
+                        // Unload the preview scene if it's the only one left
+                        EditorSceneManager.NewScene(NewSceneSetup.DefaultGameObjects);
+
+                        ResetPreviewScene();
+                    }
+                }
             };
 
             // Reset preview scene on play mode transition


### PR DESCRIPTION
In some cases, the NDMF preview scene could become the "active scene", which means
the File -> Save As menu item would attempt to save as that scene. This would then
result in the sceneSaving hook clearing the scene and an empty scene file being created.

Avoid this by always ensuring something other than the preview scene is selected;
also, close the preview scene (and create a replacement) if it's the last scene
left.
