### PR TITLE
fix: flickering selection outlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#454] Scene view selection outlines flicker in some cases
 - [#450] Improved performance when a large number of object change events are generated (e.g. when exiting animation
   mode)
 - [#441] Fixed an issue where the preview object pickable status could get out of sync with the original

--- a/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
@@ -209,10 +209,6 @@ namespace nadena.dev.ndmf.preview
                             // we render for real).
                             _proxies.Add(r, proxy);
 
-                            OriginalToProxyRenderer = OriginalToProxyRenderer.Add(r, proxy.Renderer);
-                            OriginalToProxyObject = OriginalToProxyObject.Add(r.gameObject, proxy.Renderer.gameObject);
-                            ProxyToOriginalObject = ProxyToOriginalObject.Add(proxy.Renderer.gameObject, r.gameObject);
-
                             var registry = new ObjectRegistry(null);
                             ((IObjectRegistry)registry).RegisterReplacedObject(r, proxy.Renderer);
 
@@ -303,6 +299,15 @@ namespace nadena.dev.ndmf.preview
 
             //UnityEngine.Debug.Log($"Total nodes: {total_nodes}, reused: {reused}, refresh failed: {refresh_failed}");
 
+            foreach (var (r, proxy) in _proxies)
+            {
+                proxy.FinishSetup();
+
+                OriginalToProxyRenderer = OriginalToProxyRenderer.Add(r, proxy.Renderer);
+                OriginalToProxyObject = OriginalToProxyObject.Add(r.gameObject, proxy.Renderer.gameObject);
+                ProxyToOriginalObject = ProxyToOriginalObject.Add(proxy.Renderer.gameObject, r.gameObject);
+            }
+            
 #if NDMF_DEBUG
             Debug.Log($"Pipeline {_generation} is ready");
 #endif


### PR DESCRIPTION
Previously, we swapped between two proxy renderers in order to minimize the cost of building new
game objects all the time, and to allow a new pipeline to build in parallel with rendering the
prior pipeline. This worked, but caused flickering effects, due to the unity selection system being
stateful and remembering the previously selected/highlighted instance ID.

Here, we instead have a single primary proxy used for all rendering, and use alternate objects
while setting up a shadow proxy pipeline.

Closes: #453
