### PR TITLE
perf: reduce GC overhead from GetComponent calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Changed
+- [#468] Performance improvements
 
 ### Removed
 

--- a/Runtime/RuntimeUtil.cs
+++ b/Runtime/RuntimeUtil.cs
@@ -29,8 +29,7 @@ namespace nadena.dev.ndmf.runtime
         // Shadow the VRC-provided methods to avoid deprecation warnings
         internal static T GetOrAddComponent<T>(this GameObject obj) where T : Component
         {
-            var component = obj.GetComponent<T>();
-            if (component == null) component = obj.AddComponent<T>();
+            if (!obj.TryGetComponent<T>(out var component)) component = obj.AddComponent<T>();
             return component;
         }
 
@@ -95,10 +94,10 @@ namespace nadena.dev.ndmf.runtime
         public static bool IsAvatarRoot(Transform target)
         {
 #if NDMF_VRCSDK3_AVATARS
-            return target.GetComponent<VRCAvatarDescriptor>();
+            return target.TryGetComponent<VRCAvatarDescriptor>(out _);
 #else            
-            var an = target.GetComponent<Animator>();
-            if (!an) return false;
+            if (!target.TryGetComponent<Animator>(out _)) return false;
+
             var parent = target.transform.parent;
             return !(parent && parent.GetComponentInParent<Animator>());
 #endif


### PR DESCRIPTION
Calling GetComponent on a nonexistent component allocates an error message; use TryGetComponent instead in IsAvatarRoot and GetOrAddComponent.
