### PR TITLE
feat: add Owner field to IExtensionContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#473] Added `BuildContext.SetEnableUVDistributionRecalculation` to allow opting out from the automatic call to
   `Mesh.RecalculateUVDistributionMetrics` on generated meshes.
 - [#478] Added `ProfilerScope` API
+- [#480] Added `IExtensionContext.Owner` API. Setting this property will allow errors to be correctly attributed to the
+  plugin that contains an extension context. 
 
 ### Fixed
 

--- a/Editor/API/BuildContext.cs
+++ b/Editor/API/BuildContext.cs
@@ -312,9 +312,17 @@ namespace nadena.dev.ndmf
                     {
                         var ctx = _activeExtensions[t];
                         Profiler.BeginSample("NDMF Deactivate: " + t);
+
+                        using var scope = ErrorReport.WithContext(ctx);
                         try
                         {
                             ctx.OnDeactivate(this);
+                        }
+                        catch (Exception e)
+                        {
+                            // ensure we report the exception while the error report context is set
+                            ErrorReport.ReportException(e);
+                            return;
                         }
                         finally
                         {
@@ -405,9 +413,17 @@ namespace nadena.dev.ndmf
                     if (!_activeExtensions.ContainsKey(ty))
                     {
                         Profiler.BeginSample("NDMF Activate: " + ty);
+
+                        using var scope = ErrorReport.WithContext(ctx);
                         try
                         {
                             ctx.OnActivate(this);
+                        }
+                        catch (Exception e)
+                        {
+                            // ensure we report the exception while the error report context is set
+                            ErrorReport.ReportException(e);
+                            return null;
                         }
                         finally
                         {

--- a/Editor/API/IExtensionContext.cs
+++ b/Editor/API/IExtensionContext.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -20,6 +22,12 @@ namespace nadena.dev.ndmf
         /// </summary>
         /// <param name="context"></param>
         void OnDeactivate(BuildContext context);
+        
+        /// <summary>
+        /// Return the plugin owning this extension context. Implementing this API is optional for backwards
+        /// compatibility, but is encouraged as it will provide better error messaging.
+        /// </summary>
+        PluginBase? Owner => null;
     }
 
     internal static class ExtensionContextUtil

--- a/Editor/ErrorReporting/ErrorReport.cs
+++ b/Editor/ErrorReporting/ErrorReport.cs
@@ -308,6 +308,15 @@ namespace nadena.dev.ndmf
             CurrentContext.Plugin = thePlugin;
             return scope;
         }
+
+        internal IDisposable WithContext(IExtensionContext theExtension)
+        {
+            var scope = new RestoreContextScope(this);
+            
+            if (theExtension.Owner != null) CurrentContext.Plugin = theExtension.Owner;
+
+            return scope;
+        }
         
         internal IDisposable WithContextPassName(string name)
         {


### PR DESCRIPTION
When set, errors that occur while activating or deactivating the context will
be properly attributed to the owning plugin.

Closes: #463
