### PR TITLE
fix: thread-unsafe usages of delayCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#487] Fixed a performance issue where all assets would potentially be loaded on reimport, taking a lot of time and
   memory in the process
+- [#500] Fixed a thread-safety issue which could cause various issues, including editor performance degradation.
 
 ### Changed
 

--- a/Editor/ChangeStream/ObjectWatcher.cs
+++ b/Editor/ChangeStream/ObjectWatcher.cs
@@ -338,22 +338,23 @@ namespace nadena.dev.ndmf.cs
 
                     if (Thread.CurrentThread.ManagedThreadId == _targetThread)
                     {
-                        DoDispose();
+                        DoDispose(_orig);
                     }
                     else
                     {
-                        var orig = _orig;
-                        EditorApplication.delayCall += DoDispose;
+                        NDMFSyncContext.Context.Post(targets => DoDispose((IDisposable[])targets), _orig);
                     }
 
                     _orig = null;
                 }
             }
 
-            private void DoDispose()
+            private static void DoDispose(IDisposable[] targets)
             {
-                if (_orig == null) return;
-                foreach (var orig in _orig) orig.Dispose();
+                foreach (var orig in targets)
+                {
+                    orig.Dispose();
+                }
             }
         }
 

--- a/Editor/ChangeStream/PropertyMonitor.cs
+++ b/Editor/ChangeStream/PropertyMonitor.cs
@@ -109,7 +109,9 @@ namespace nadena.dev.ndmf.cs
                     var (instanceId, reg) = pair;
 
                     // Wake up all listeners to see if their monitored value has changed
+                    Profiler.BeginSample("FirePropsUpdated", EditorUtility.InstanceIDToObject(instanceId));
                     reg._listeners.Fire(PropertyMonitorEvent.PropsUpdated);
+                    Profiler.EndSample();
 
                     if (!reg._listeners.HasListeners() || reg._obj == null) toRemove.Add(instanceId);
 
@@ -136,7 +138,7 @@ namespace nadena.dev.ndmf.cs
         private static async Task Yield()
         {
             var tcs = new TaskCompletionSource<bool>();
-            EditorApplication.delayCall += () => { tcs.SetResult(true); };
+            NDMFSyncContext.Context.Post(tcs_ => ((TaskCompletionSource<bool>)tcs_).TrySetResult(true), tcs);
 
             await tcs.Task;
         }

--- a/Editor/ChangeStream/RepaintTrigger.cs
+++ b/Editor/ChangeStream/RepaintTrigger.cs
@@ -1,26 +1,31 @@
-﻿using UnityEditor;
+﻿using nadena.dev.ndmf.preview;
+using UnityEditor;
 
 namespace nadena.dev.ndmf.cs
 {
     internal static class RepaintTrigger
     {
+        private static object _lock = new();
         private static bool _requested;
 
         public static void RequestRepaint()
         {
-            if (_requested) return;
-
-            // Note: We need to delay two frames to avoid visual flicker
-            _requested = true;
-            EditorApplication.delayCall += () =>
+            lock (_lock)
             {
-                SceneView.RepaintAll();
-                EditorApplication.delayCall += () =>
+                if (_requested) return;
+
+                // Note: We need to delay two frames to avoid visual flicker
+                _requested = true;
+                NDMFSyncContext.Context.Post(_ =>
                 {
-                    _requested = false;
                     SceneView.RepaintAll();
-                };
-            };
+                    EditorApplication.delayCall += () =>
+                    {
+                        _requested = false;
+                        SceneView.RepaintAll();
+                    };
+                }, null);
+            }
         }
     }
 }

--- a/Editor/PreviewSystem/ComputeContext.cs
+++ b/Editor/PreviewSystem/ComputeContext.cs
@@ -35,7 +35,7 @@ namespace nadena.dev.ndmf.preview
                 if (_pendingInvalidatesScheduled) return;
                 
                 _pendingInvalidatesScheduled = true;
-                EditorApplication.delayCall += FlushInvalidates;
+                NDMFSyncContext.Context.Post(_ => FlushInvalidates(), null);
             }
         }
 

--- a/Editor/PreviewSystem/TaskUtil.cs
+++ b/Editor/PreviewSystem/TaskUtil.cs
@@ -13,29 +13,10 @@ namespace nadena.dev.ndmf.preview
         {
             _mainThread = Thread.CurrentThread;
         }
-        
-        internal static void OnMainThread(EditorApplication.CallbackFunction action)
-        {
-            if (Thread.CurrentThread == _mainThread)
-            {
-                action();
-            }
-            else
-            {
-                EditorApplication.delayCall += action;
-            }
-        }
 
         internal static void OnMainThread<T>(T target, Action<T> receiver)
         {
-            if (Thread.CurrentThread == _mainThread)
-            {
-                receiver((T) target);
-            }
-            else
-            {
-                EditorApplication.delayCall += () => receiver((T) target);
-            }
+            NDMFSyncContext.RunOnMainThread(() => receiver(target));
         }
     }
 }


### PR DESCRIPTION
EditorApplication.delayCall cannot be used to safely send
callbacks to unity's main thread - instead, we capture unity's
SynchronizationContext to give us a way to remote in.
