### PR TITLE
fix: freezes encountered by some users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#507] Fixed a potential editor freeze bug
 
 ### Changed
 
 ### Removed
+- [#507] Removed the `NDMFSyncContext.RunOnMainThread` API which was accidentally addded in 1.6.3.
+  This might be re-added in 1.7.0.
 
 ### Security
 

--- a/Editor/PreviewSystem/ComputeContext.cs
+++ b/Editor/PreviewSystem/ComputeContext.cs
@@ -145,7 +145,7 @@ namespace nadena.dev.ndmf.preview
                     arg0: this
                 ).EventId;
                 
-                TaskUtil.OnMainThread(this, DoInvalidate);
+                NDMFSyncContext.RunOnMainThread(target => DoInvalidate((ComputeContext)target), this);
             };
             Description = description;
 

--- a/Editor/PreviewSystem/Task/NDMFSyncContext.cs
+++ b/Editor/PreviewSystem/Task/NDMFSyncContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using JetBrains.Annotations;
 using UnityEditor;
 using UnityEngine;
 
@@ -15,20 +16,23 @@ namespace nadena.dev.ndmf.preview
     {
         public static SynchronizationContext Context = new Impl();
         private static Impl InternalContext = (Impl)Context;
-
+        
         /// <summary>
-        /// Runs the given function on the unity main thread - synchronously if possible.
+        ///    Runs the given function on the unity main thread, passing the given target as an argument.
+        ///    The function will be invoked synchronously if called from the main thread; otherwise, it will be
+        ///    run asynchronously.
         /// </summary>
-        /// <param name="cb"></param>
-        public static void RunOnMainThread(EditorApplication.CallbackFunction cb)
+        /// <param name="receiver"></param>
+        /// <param name="target"></param>
+        internal static void RunOnMainThread(SendOrPostCallback receiver, object target)
         {
             if (Thread.CurrentThread.ManagedThreadId == InternalContext.unityMainThreadId)
             {
-                cb();
+                receiver(target);
             }
             else
             {
-                Context.Send(_ => cb(), null);
+                Context.Post(receiver, target);
             }
         }
         

--- a/Editor/PreviewSystem/TaskUtil.cs
+++ b/Editor/PreviewSystem/TaskUtil.cs
@@ -13,10 +13,5 @@ namespace nadena.dev.ndmf.preview
         {
             _mainThread = Thread.CurrentThread;
         }
-
-        internal static void OnMainThread<T>(T target, Action<T> receiver)
-        {
-            NDMFSyncContext.RunOnMainThread(() => receiver(target));
-        }
     }
 }


### PR DESCRIPTION
Previously, `TaskUtil.OnMainThread` was asynchronous, allowing for the
editor to remain responsive even if something was spamming
invalidations. However, with the prior change fdaee911a3, this was
accidentally changed to be synchronous. This seems to cause editor
freezes in some situations.

This change reverts `TaskUtil.OnMainThread` to be asynchronous.

Closes: #507
