### PR TITLE
perf: Ignore ChangeScene events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Performance improvements (#515)
 
 ### Changed
 

--- a/Editor/ChangeStream/ChangeStreamMonitor.cs
+++ b/Editor/ChangeStream/ChangeStreamMonitor.cs
@@ -74,11 +74,16 @@ namespace nadena.dev.ndmf.cs
 
                 case ObjectChangeKind.ChangeScene:
                 {
+                    /*
                     using (OpenTrace(stream, i))
                     using (new ProfilerScope("ChangeScene"))
                     {
                         ObjectWatcher.Instance.Hierarchy.InvalidateAll();
                     }
+                    */
+
+                    // Unfortunately there are too many spurious sources for ChangeScene - we'll have to hope that
+                    // PropertyMonitor can catch unreported changes. 
 
                     break;
                 }


### PR DESCRIPTION
ChangeScene events are invoked far too frequently, primarily as a result of `EditorUtility.SetDirty`, and can't be used as a
reliable indicator that anything changed. As such, ignore them in ChangeStreamMonitor.
