### PR TITLE
perf: Reduce component structure check overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Performance improvements (#516)
 
 ### Changed
 

--- a/Editor/ChangeStream/ChangeStreamMonitor.cs
+++ b/Editor/ChangeStream/ChangeStreamMonitor.cs
@@ -272,7 +272,7 @@ namespace nadena.dev.ndmf.cs
         {
             var instanceId = data.instanceId;
 
-            ObjectWatcher.Instance.Hierarchy.FireStructureChangeEvent(instanceId);
+            ObjectWatcher.Instance.Hierarchy.MaybeFireStructureChangeEvent(instanceId);
         }
 
         private static void OnChangeGameObjectStructureHierarchy(ChangeGameObjectStructureHierarchyEventArgs data)

--- a/Editor/ChangeStream/PropertyMonitor.cs
+++ b/Editor/ChangeStream/PropertyMonitor.cs
@@ -108,6 +108,11 @@ namespace nadena.dev.ndmf.cs
                     
                     var (instanceId, reg) = pair;
 
+                    if (reg._obj is GameObject)
+                    {
+                        ObjectWatcher.Instance.Hierarchy.RequestComponentStructureCheck(instanceId);
+                    }
+
                     // Wake up all listeners to see if their monitored value has changed
                     Profiler.BeginSample("FirePropsUpdated", EditorUtility.InstanceIDToObject(instanceId));
                     reg._listeners.Fire(PropertyMonitorEvent.PropsUpdated);

--- a/Editor/PreviewSystem/ComputeContext/SingleObjectQueries.cs
+++ b/Editor/PreviewSystem/ComputeContext/SingleObjectQueries.cs
@@ -249,8 +249,9 @@ namespace nadena.dev.ndmf.preview
         {
             if (obj == null) return null;
 
-            return ObjectWatcher.Instance.MonitorGetComponent(obj, ctx,
-                () => obj != null ? InternalGetComponent<C>(obj) : null);
+            ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, false);
+
+            return obj.GetComponent<C>();
         }
 
         public static Component GetComponent(this ComputeContext ctx, GameObject obj, Type type,
@@ -260,8 +261,9 @@ namespace nadena.dev.ndmf.preview
         {
             if (obj == null) return null;
 
-            return ObjectWatcher.Instance.MonitorGetComponent(obj, ctx,
-                () => obj != null ? InternalGetComponent(obj, type) : null);
+            ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, false);
+
+            return obj.GetComponent(type);
         }
 
         public static C[] GetComponents<C>(this ComputeContext ctx, GameObject obj,
@@ -271,8 +273,9 @@ namespace nadena.dev.ndmf.preview
         {
             if (obj == null) return Array.Empty<C>();
 
-            return ObjectWatcher.Instance.MonitorGetComponents(obj, ctx,
-                () => obj != null ? obj.GetComponents<C>() : Array.Empty<C>(), false);
+            ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, false);
+
+            return obj.GetComponents<C>();
         }
 
         public static Component[] GetComponents(this ComputeContext ctx, GameObject obj, Type type,
@@ -282,8 +285,9 @@ namespace nadena.dev.ndmf.preview
         {
             if (obj == null) return Array.Empty<Component>();
 
-            return ObjectWatcher.Instance.MonitorGetComponents(obj, ctx,
-                () => obj != null ? obj.GetComponents(type) : Array.Empty<Component>(), false);
+            ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, false);
+
+            return obj.GetComponents(type);
         }
 
         public static C[] GetComponentsInChildren<C>(this ComputeContext ctx, GameObject obj, bool includeInactive,
@@ -294,8 +298,9 @@ namespace nadena.dev.ndmf.preview
         {
             if (obj == null) return Array.Empty<C>();
 
-            return ObjectWatcher.Instance.MonitorGetComponents(obj, ctx,
-                () => obj != null ? obj.GetComponentsInChildren<C>(includeInactive) : Array.Empty<C>(), true);
+            ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, true);
+
+            return obj.GetComponentsInChildren<C>(includeInactive);
         }
 
         public static Component[] GetComponentsInChildren(this ComputeContext ctx, GameObject obj, Type type,
@@ -306,9 +311,9 @@ namespace nadena.dev.ndmf.preview
         {
             if (obj == null) return Array.Empty<Component>();
 
-            return ObjectWatcher.Instance.MonitorGetComponents(obj, ctx,
-                () => obj != null ? obj.GetComponentsInChildren(type, includeInactive) : Array.Empty<Component>(),
-                true);
+            ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, true);
+
+            return obj.GetComponentsInChildren(type, includeInactive);
         }
     }
 }

--- a/Editor/PreviewSystem/Task/NDMFSyncContext.cs
+++ b/Editor/PreviewSystem/Task/NDMFSyncContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
-using JetBrains.Annotations;
 using UnityEditor;
 using UnityEngine;
 
@@ -15,7 +14,7 @@ namespace nadena.dev.ndmf.preview
     public static class NDMFSyncContext
     {
         public static SynchronizationContext Context = new Impl();
-        private static Impl InternalContext = (Impl)Context;
+        internal static Impl InternalContext = (Impl)Context;
         
         /// <summary>
         ///    Runs the given function on the unity main thread, passing the given target as an argument.
@@ -61,7 +60,7 @@ namespace nadena.dev.ndmf.preview
             }
         }
 
-        private class Impl : SynchronizationContext
+        internal class Impl : SynchronizationContext
         {
             private SynchronizationContext _unityMainThreadContext;
             
@@ -78,7 +77,7 @@ namespace nadena.dev.ndmf.preview
                 EditorApplication.delayCall += () =>
                 {
                     // Obtain the unity synchronization context
-                    _unityMainThreadContext = SynchronizationContext.Current;
+                    _unityMainThreadContext = Current;
                     unityMainThreadId = Thread.CurrentThread.ManagedThreadId;
 
                     Turn(); // process anything that was queued before we had a chance to initialize
@@ -99,7 +98,8 @@ namespace nadena.dev.ndmf.preview
                 ((Impl)state).Turn();
             }
 
-            private void Turn()
+            // visible for tests
+            internal void Turn()
             {
                 lock (_lock)
                 {

--- a/UnitTests~/RQ-EditorTests/ShadowHierarchyTest.cs
+++ b/UnitTests~/RQ-EditorTests/ShadowHierarchyTest.cs
@@ -214,7 +214,8 @@ namespace UnitTests.EditorTests
                 return false;
             }, ctx);
             
-            shadow.FireStructureChangeEvent(obj.GetInstanceID());
+            obj.AddComponent<MeshFilter>();
+            shadow.MaybeFireStructureChangeEvent(obj.GetInstanceID());
             
             Assert.AreEqual(1, events.Count);
             Assert.AreEqual(HierarchyEvent.SelfComponentsChanged, events[0]);
@@ -239,7 +240,9 @@ namespace UnitTests.EditorTests
             }, ctx);
             
             shadow.EnableComponentMonitoring(parent);
-            shadow.FireStructureChangeEvent(child.GetInstanceID());
+            
+            child.AddComponent<MeshFilter>();
+            shadow.MaybeFireStructureChangeEvent(child.GetInstanceID());
             
             Assert.AreEqual(1, events.Count);
             Assert.AreEqual(HierarchyEvent.ChildComponentsChanged, events[0]);
@@ -274,8 +277,9 @@ namespace UnitTests.EditorTests
             Assert.IsTrue(events.Contains(HierarchyEvent.ChildComponentsChanged));
             
             events.Clear();
-            
-            shadow.FireStructureChangeEvent(p3.GetInstanceID());
+
+            p3.AddComponent<MeshFilter>();
+            shadow.MaybeFireStructureChangeEvent(p3.GetInstanceID());
             
             // Assert.AreEqual(1, events.Count); - TODO - deduplicate events
             Assert.IsTrue(events.Contains(HierarchyEvent.ChildComponentsChanged));
@@ -466,8 +470,7 @@ namespace UnitTests.EditorTests
             Assert.AreEqual(iid1, iid2a);
             Assert.AreEqual(iid2, iid1a);
             
-            shadow.FireObjectChangeNotification(iid1);
-            shadow.FireObjectChangeNotification(iid2);
+            shadow.FireObjectChangeNotification(o2.GetInstanceID());
             
             Assert.Contains((1, HierarchyEvent.ChildComponentsChanged), events);
             Assert.Contains((2, HierarchyEvent.SelfComponentsChanged), events);


### PR DESCRIPTION
Previously, we issued change events whenever component order changed; this resulted in spurious invocations of listeners,
which when did (potentially very expensive) redundant checks of what components were in their children. In particular, this
was done whenever a _component_ changed; this was probably a bug, as a change event on the _GameObject_ is issued when
component order changes.

This change makes a few adjustments to fix this:
* We record the child component list in the ShadowGameObject, and only generate change events if it actually changes.
* We only perform component structure checks when _game objects_ change, not when the components themselves change.
* We avoid registering complex filters for component structure events; those filters were expensive, frequently redundantly
registered, and are no longer needed with the new ShadowGameObject component tracking.

Closes: #513

perf: Remove redundant listener filters for MonitorGetComponents

Now that the shadow hierarchy is checking for component structure changes, we don't need to perform these checks in SingleObjectQueries.

Avoiding doing these checks there avoids redundant processing, which is particularly important since these will all generally
 converge into the same invalidation.
