### PR TITLE
fix: partial fix for test build button becoming disabled after test build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Performance improvements (#515 #516)
+- "Test build" button is disabled after test-building an avatar that is not a scene root (#518)
 
 ### Changed
 

--- a/Editor/ErrorReporting/UI/ErrorReportWindow.cs
+++ b/Editor/ErrorReporting/UI/ErrorReportWindow.cs
@@ -227,6 +227,7 @@ namespace nadena.dev.ndmf.ui
         {
             if (_avatarRoot == null) return;
 
+            var currentAvatar = _avatarRoot;
             var clone = Instantiate(_avatarRoot);
 
             try
@@ -236,6 +237,16 @@ namespace nadena.dev.ndmf.ui
                 AvatarProcessor.ProcessAvatar(clone);
 
                 CurrentReport = ErrorReport.Reports.FirstOrDefault();
+
+                // HACK: If the avatar is not at the root of the scene, we end up being unable to find it (because the
+                // clone is at the root). For now, we force reset the avatar root here, but we should find a more
+                // reliable way to find the original avatar. This probably needs to be plugged into the platform API
+                // system, so for now we'll do this workaround to ensure that the test build button remains enabled.
+                // See https://github.com/bdunderscore/ndmf/issues/517
+
+                // Note: We avoid the property accessor as it would clear the CurrentReport property.
+                _avatarRoot = currentAvatar;
+                UpdateContents();
             }
             finally
             {


### PR DESCRIPTION
This fixes an issue where the "test build" button would become disabled after testing an avatar which is not at the root of the scene. Note that the underlying issue (#493) remains outstanding for now, but this workaround should deal with the immediate bug report.

Closes: #493
