### PR TITLE
fix: path renaming skips synced layers

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#553] Path renaming ignored motion overrides on synced layers 
 
 ### Changed
 

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualLayer.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualLayer.cs
@@ -210,6 +210,10 @@ namespace nadena.dev.ndmf.animator
         protected override IEnumerable<VirtualNode> _EnumerateChildren()
         {
             if (StateMachine != null) yield return StateMachine;
+            foreach (var motion in SyncedLayerMotionOverrides.Values)
+            {
+                yield return motion;
+            }
         }
     }
 }

--- a/UnitTests~/AnimationServices/VirtualLayerTest.cs
+++ b/UnitTests~/AnimationServices/VirtualLayerTest.cs
@@ -189,6 +189,19 @@ namespace UnitTests.AnimationServices
             Assert.AreEqual(typeof(TestStateBehavior1), syncedLayer.GetOverrideBehaviours(behavior)[0].GetType());
         }
 
+        [Test]
+        public void VirtualLayer_EnumeratesSyncedLayerMotionOverrides()
+        {
+            var testController = LoadAsset<AnimatorController>("TestAssets/SyncedLayers.controller");
+            var context = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+            var virtualController = context.Clone(testController);
+            
+            var virtSyncedLayer = virtualController.Layers.ToList()[1];
+            var motion = virtSyncedLayer.EnumerateChildren().OfType<VirtualClip>().FirstOrDefault();
+            Assert.IsNotNull(motion);
+            Assert.AreEqual("c2", motion.Name);
+        }
+
         private class TestPlatform : IPlatformAnimatorBindings
         {
             public HashSet<StateMachineBehaviour> calledVirtualize = new(), calledCommit = new();


### PR DESCRIPTION
Reported in https://github.com/bdunderscore/modular-avatar/issues/1410