### PR TITLE
fix: first layer weights are not interpreted as 1 in some cases

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#554] Fix issues where the first layer of an animator controller might not be interpreted as having weight 1
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#543] Exceptions thrown when deactivating extension contexts can result in an infinite loop
 - [#547] ProcessAvatar ignores enclosing `ErrorReport.CaptureErrors` scopes
+- [#554] Fix issues where the first layer of an animator controller might not be interpreted as having weight 1
 
 ### Changed
 

--- a/Editor/API/AnimatorServices/VirtualControllerContext.cs
+++ b/Editor/API/AnimatorServices/VirtualControllerContext.cs
@@ -318,6 +318,8 @@ namespace nadena.dev.ndmf.animator
                     kv =>
                     {
                         commitContext.ActiveInnateLayerKey = kv.Key;
+                        kv.Value.VirtualController!.NormalizeFirstLayerWeights();
+                        
                         var committed =
                             (RuntimeAnimatorController)commitContext.CommitObject(kv.Value.VirtualController!);
                         kv.Value.MarkCommitted(committed);

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualAnimatorController.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualAnimatorController.cs
@@ -170,6 +170,31 @@ namespace nadena.dev.ndmf.animator
             }
         }
 
+        /// <summary>
+        ///     Sets the layer weight for all layers with a zero
+        ///     [OriginalPhysicalLayerIndex](xref:VirtualLayer.OriginalPhysicalLayerIndex)
+        ///     to one, and sets [OriginalPhysicalLayerIndex](xref:VirtualLayer.OriginalPhysicalLayerIndex) to null for all
+        ///     layers except the first layer.
+        ///     This should be invoked after merging controllers to correct for the fact that Unity considers the first layer
+        ///     to always have weight one, even if the serialized weight is not one.
+        ///     This function is automatically invoked when deactivating the VirtualControllerContext.
+        /// </summary>
+        public void NormalizeFirstLayerWeights()
+        {
+            var isFirst = true;
+            foreach (var layer in Layers)
+            {
+                if (layer.OriginalPhysicalLayerIndex == 0)
+                {
+                    layer.DefaultWeight = 1;
+                }
+
+                layer.OriginalPhysicalLayerIndex = isFirst ? 0 : null;
+
+                isFirst = false;
+            }
+        }
+
         internal static VirtualAnimatorController Clone(CloneContext context, RuntimeAnimatorController controller)
         {
             switch (controller)

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualLayer.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualLayer.cs
@@ -21,6 +21,12 @@ namespace nadena.dev.ndmf.animator
         /// </summary>
         public int VirtualLayerIndex { get; }
 
+        /// <summary>
+        ///     The original physical layer index, if this layer was cloned from an existing layer.
+        ///     <see cref="VirtualAnimatorController.NormalizeFirstLayerWeights" />
+        /// </summary>
+        public int? OriginalPhysicalLayerIndex { get; set; }
+
         private VirtualStateMachine? _stateMachine;
 
         public VirtualStateMachine? StateMachine
@@ -124,6 +130,7 @@ namespace nadena.dev.ndmf.animator
         private VirtualLayer(CloneContext context, AnimatorControllerLayer layer, int physicalLayerIndex)
         {
             VirtualLayerIndex = context.CloneSourceToVirtualLayerIndex(physicalLayerIndex);
+            OriginalPhysicalLayerIndex = physicalLayerIndex;
             _name = layer.name;
             AvatarMask = layer.avatarMask == null ? null : context.Clone(layer.avatarMask);
             BlendingMode = layer.blendingMode;

--- a/UnitTests~/AnimationServices/GenericPlatformTests.cs
+++ b/UnitTests~/AnimationServices/GenericPlatformTests.cs
@@ -76,5 +76,34 @@ namespace UnitTests.AnimationServices
             
             Assert.AreNotEqual(startingController, childComponent.AnimatorController);
         }
+
+        [Test]
+        public void NormalizesOnDeactivate(
+            [ValueSource(nameof(CreateAvatarSource))]
+            (string, Func<GenericPlatformTests, GameObject>) createAvatar
+        )
+        {
+            var root = createAvatar.Item2(this);
+            
+            var child = TrackObject(new GameObject("child"));
+            child.transform.parent = root.transform;
+            var childComponent = child.AddComponent<VirtualizedComponent>();
+            
+            var startingController = new AnimatorController();
+            childComponent.AnimatorController = startingController;
+            
+            startingController.layers = new AnimatorControllerLayer[]
+            {
+                new AnimatorControllerLayer {name = "Layer1", defaultWeight = 0f, stateMachine = TrackObject(new AnimatorStateMachine())},
+            };
+            
+            var buildContext = CreateContext(root);
+            
+            buildContext.ActivateExtensionContext<VirtualControllerContext>();
+            buildContext.DeactivateExtensionContext<VirtualControllerContext>();
+
+            var newController = (AnimatorController) childComponent.AnimatorController;
+            Assert.AreEqual(1f, newController.layers[0].defaultWeight);
+        }
     }
 }

--- a/UnitTests~/AnimationServices/VirtualAnimatorControllerTest.cs
+++ b/UnitTests~/AnimationServices/VirtualAnimatorControllerTest.cs
@@ -190,5 +190,46 @@ namespace UnitTests.AnimationServices
             Assert.AreEqual("t-10", layers[2].Name);
             Assert.AreEqual("t0.1", layers[3].Name);
         }
+        
+        
+        [Test]
+        public void TestLayerNormalization()
+        {
+            var cloneContext = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+
+            var ac1 = TrackObject(new AnimatorController());
+            ac1.layers = new[]
+            {
+                new AnimatorControllerLayer()
+                {
+                    name = "l1",
+                    defaultWeight = 0,
+                    stateMachine = TrackObject(new AnimatorStateMachine())
+                }
+            };
+            
+            var ac2 = TrackObject(new AnimatorController());
+            ac2.layers = new[]
+            {
+                new AnimatorControllerLayer()
+                {
+                    name = "l2",
+                    defaultWeight = 0,
+                    stateMachine = TrackObject(new AnimatorStateMachine())
+                }
+            };
+            
+            var vac1 = cloneContext.Clone(ac1);
+            var vac2 = cloneContext.Clone(ac2);
+
+            vac1.AddLayer(new LayerPriority(0), vac2.Layers.First());
+            
+            vac1.NormalizeFirstLayerWeights();
+            
+            var commitContext = new CommitContext();
+            var committed = commitContext.CommitObject(vac1);
+            
+            Assert.AreEqual(1, committed.layers[1].defaultWeight);
+        }
     }
 }

--- a/UnitTests~/AnimationServices/VirtualControllerContextTests.cs
+++ b/UnitTests~/AnimationServices/VirtualControllerContextTests.cs
@@ -1,0 +1,11 @@
+﻿using System.Linq;
+using nadena.dev.ndmf.animator;
+using NUnit.Framework;
+using UnityEditor.Animations;
+
+namespace UnitTests.AnimationServices
+{
+    public class VirtualControllerContextTests : TestBase
+    {
+    }
+}

--- a/UnitTests~/AnimationServices/VirtualControllerContextTests.cs.meta
+++ b/UnitTests~/AnimationServices/VirtualControllerContextTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 77648f270fc04976bb21bfc02ec0cc4c
+timeCreated: 1742351809


### PR DESCRIPTION
Closes: https://github.com/bdunderscore/modular-avatar/issues/1507
