### PR TITLE
feat: add support for controlling platforms for pass execution

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [#572] Added `Sequence.OnAllPlatforms()` and `Sequence.OnPlatforms()` methods, and the `WellKnownPlatforms` class.
+  - These are in preparation for NDMF's multiplatform support, and configure which platforms passes run on.
+  - By default, passes run only on VRChat SDK 3.0.
+- [#572] Added `[RunsOnAllPlatforms]` and `[RunsOnPlatform]` attributes as well
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [#572] Added `Sequence.OnAllPlatforms()` and `Sequence.OnPlatforms()` methods, and the `WellKnownPlatforms` class.
+  - These are in preparation for NDMF's multiplatform support, and configure which platforms passes run on.
+  - By default, passes run only on VRChat SDK 3.0.
+- [#572] Added `[RunsOnAllPlatforms]` and `[RunsOnPlatform]` attributes as well
 
 ### Fixed
 

--- a/Editor/API/Attributes/RunsOnPlatforms.cs
+++ b/Editor/API/Attributes/RunsOnPlatforms.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace nadena.dev.ndmf
+{
+    /// <summary>
+    ///     Declares that the attached Pass or Plugin runs on all NDMF platforms. Must not be used in conjunction with RunsOnPlatform.
+    ///     <p />
+    ///     If this attribute is attached to a Pass class, any configuration performed on the `Sequence` class will be ignored
+    ///     for this class. If this attribute is attached to a Plugin class, Sequences will start with all platforms enabled.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    [PublicAPI]
+    public sealed class RunsOnAllPlatforms : Attribute
+    {
+    }
+
+    /// <summary>
+    ///     Declares that the attached Pass or Plugin runs on all NDMF platforms. Must not be used in conjunction with
+    ///     RunsOnAllPlatforms.
+    ///     If your pass supports multiple platforms, this attribute can be attached multiple times to declares this.
+    ///     <p />
+    ///     If this attribute is attached to a Pass class, any configuration performed on the `Sequence` class will be ignored
+    ///     for this class. If this attribute is attached to a Plugin class, Sequences will start with the specified
+    ///     platforms enabled.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [PublicAPI]
+    public sealed class RunsOnPlatform : Attribute
+    {
+        public string Platform { get; }
+
+        public RunsOnPlatform(string platform)
+        {
+            Platform = platform;
+        }
+    }
+}

--- a/Editor/API/Attributes/RunsOnPlatforms.cs
+++ b/Editor/API/Attributes/RunsOnPlatforms.cs
@@ -16,9 +16,9 @@ namespace nadena.dev.ndmf
     }
 
     /// <summary>
-    ///     Declares that the attached Pass or Plugin runs on all NDMF platforms. Must not be used in conjunction with
+    ///     Declares that the attached Pass or Plugin runs on one or more specified NDMF platforms. Must not be used in conjunction with
     ///     RunsOnAllPlatforms.
-    ///     If your pass supports multiple platforms, this attribute can be attached multiple times to declares this.
+    ///     If your pass supports multiple platforms, this attribute can be attached multiple times to declare this.
     ///     <p />
     ///     If this attribute is attached to a Pass class, any configuration performed on the `Sequence` class will be ignored
     ///     for this class. If this attribute is attached to a Plugin class, Sequences will start with the specified

--- a/Editor/API/Attributes/RunsOnPlatforms.cs.meta
+++ b/Editor/API/Attributes/RunsOnPlatforms.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e048fcf9946d4d69b2bcbccdacd7c826
+timeCreated: 1743823418

--- a/Editor/API/Fluent/PluginInfo.cs
+++ b/Editor/API/Fluent/PluginInfo.cs
@@ -1,6 +1,11 @@
-﻿#region
+﻿#nullable enable
 
+#region
+
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using nadena.dev.ndmf.fluent;
 using nadena.dev.ndmf.model;
 
@@ -14,17 +19,37 @@ namespace nadena.dev.ndmf
         private readonly IPluginInternal _plugin;
         private int sequenceIndex = 0;
         private HashSet<BuildPhase> _createdInnatePhases = new HashSet<BuildPhase>();
+        private ImmutableHashSet<string>? _defaultPlatforms;
 
         public PluginInfo(SolverContext solverContext, IPluginInternal plugin)
         {
             _solverContext = solverContext;
             _plugin = plugin;
+
+            _defaultPlatforms = ImmutableHashSet<string>.Empty.Add(WellKnownPlatforms.VRChatAvatar30);
+            if (plugin.GetType().GetCustomAttributes(typeof(RunsOnAllPlatforms), false).Length > 0)
+            {
+                _defaultPlatforms = null;
+            }
+
+            var supportedPlatforms = plugin.GetType().GetCustomAttributes(typeof(RunsOnPlatform), false)
+                .OfType<RunsOnPlatform>()
+                .Select(p => p.Platform)
+                .ToImmutableHashSet();
+            if (_defaultPlatforms == null && supportedPlatforms.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"Plugin {plugin.GetType().Name} has both [RunsOnAllPlatforms] and [RunsOnPlatform] attributes. Please use one or the other.");
+            } else if (supportedPlatforms.Count > 0)
+            {
+                _defaultPlatforms = supportedPlatforms;
+            }
         }
 
         internal Sequence NewSequence(BuildPhase phase)
         {
             string sequencePrefix = _plugin.QualifiedName + "/sequence#" + sequenceIndex++;
-            return new Sequence(phase, _solverContext, _plugin, sequencePrefix);
+            return new Sequence(phase, _solverContext, _plugin, sequencePrefix, _defaultPlatforms);
         }
     }
 }

--- a/Editor/API/Fluent/WellKnownPlatforms.cs
+++ b/Editor/API/Fluent/WellKnownPlatforms.cs
@@ -1,0 +1,19 @@
+﻿using JetBrains.Annotations;
+
+namespace nadena.dev.ndmf.model
+{
+    [PublicAPI]
+    public static class WellKnownPlatforms
+    {
+        /// <summary>
+        /// A NDMF built-in platform that assumes nothing beyond basic ability to render meshes.
+        /// </summary>
+        public const string Generic = "nadena.dev.ndmf.generic";
+        public const string VRChatAvatar30 = "nadena.dev.ndmf.vrchat.avatar3";
+        public const string Resonite = "nadena.dev.ndmf.resonite";
+        
+        // VRM?
+        // Chillout?
+        // Warudo?
+    }
+}

--- a/Editor/API/Fluent/WellKnownPlatforms.cs.meta
+++ b/Editor/API/Fluent/WellKnownPlatforms.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: adc3303929af48c1acd32369d2091132
+timeCreated: 1743817842

--- a/Editor/API/Model/SolverContext.cs
+++ b/Editor/API/Model/SolverContext.cs
@@ -1,8 +1,11 @@
-﻿#region
+﻿#nullable enable
+
+#region
 
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using JetBrains.Annotations;
 
 #endregion
 
@@ -35,7 +38,7 @@ namespace nadena.dev.ndmf.model
     {
         public List<SolverPass> Passes { get; } = new List<SolverPass>();
         public List<Constraint> Constraints { get; } = new List<Constraint>();
-
+        
         private Dictionary<(string, BuildPhase), InnatePhases> _innatePhases =
             new Dictionary<(string, BuildPhase), InnatePhases>();
 

--- a/Editor/API/Solver/PluginResolver.cs
+++ b/Editor/API/Solver/PluginResolver.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Codice.Client.BaseCommands;
 using JetBrains.Annotations;
 using nadena.dev.ndmf.model;
 using nadena.dev.ndmf.preview;
@@ -112,6 +113,9 @@ namespace nadena.dev.ndmf
             Dictionary<BuildPhase, List<(SolverPass, SolverPass, ConstraintType)>>
                 constraintsByPhase = new Dictionary<BuildPhase, List<(SolverPass, SolverPass, ConstraintType)>>();
 
+            // Temporary - until we have merge the rest of platform support
+            solverContext.Passes.RemoveAll(p => p.Platforms?.Contains(WellKnownPlatforms.VRChatAvatar30) == false);
+            
             foreach (var pass in solverContext.Passes)
             {
                 if (!passesByPhase.TryGetValue(pass.Phase, out var list))

--- a/Editor/InternalPasses/InternalPasses.cs
+++ b/Editor/InternalPasses/InternalPasses.cs
@@ -17,7 +17,9 @@ namespace nadena.dev.ndmf
         {
             InPhase(BuildPhase.Resolving)
                 .Run(RemoveMissingScriptComponents.Instance)
-                .Then.Run(RemoveEditorOnlyPass.Instance);
+                .Then.Run(RemoveEditorOnlyPass.Instance)
+                .Then.OnPlatforms("ndmf/nonexistent")
+                .Run("TEST - Should not run (incompatible platform)", _ => { });
         }
     }
 }

--- a/Editor/InternalPasses/RemoveEditorOnlyPass.cs
+++ b/Editor/InternalPasses/RemoveEditorOnlyPass.cs
@@ -11,7 +11,9 @@ namespace nadena.dev.ndmf.builtin
     /// This pass removes all objects tagged with "EditorOnly" from the avatar. It will be run early in the Resolving
     /// phase; if you need to run before this, declare a BeforePass constraint on this type.
     /// </summary>
-    [NDMFInternalEarlyPass] [NDMFInternal]
+    [NDMFInternalEarlyPass]
+    [NDMFInternal]
+    [RunsOnAllPlatforms]
     public sealed class RemoveEditorOnlyPass : Pass<RemoveEditorOnlyPass>
     {
         public override string QualifiedName => "nadena.dev.ndmf.system.RemoveEditorOnly";

--- a/Editor/InternalPasses/RemoveMissingScriptComponents.cs
+++ b/Editor/InternalPasses/RemoveMissingScriptComponents.cs
@@ -1,5 +1,4 @@
-﻿using nadena.dev.ndmf;
-using nadena.dev.ndmf.runtime;
+﻿using nadena.dev.ndmf.runtime;
 using UnityEditor;
 using UnityEngine;
 
@@ -10,6 +9,7 @@ namespace nadena.dev.ndmf.builtin
     /// (for some reason) you need to run before this, declare a BeforePass constraint on this type.
     /// </summary>
     [NDMFInternal]
+    [RunsOnAllPlatforms]
     public sealed class RemoveMissingScriptComponents : Pass<RemoveMissingScriptComponents>
     {
         protected override void Execute(BuildContext context)


### PR DESCRIPTION
This adds new APIs to control which platforms a pass runs on.
For compatibility, if there is no platform support declaration, passes
will run only on VRCSDK 3.0.

Note that this only adds the APIs (and suppresses passes not compatible
with VRCSDK3.0). Full support will come in later changes, but this
change encompasses the semver minor release changes.
