### PR TITLE
fix: animator play audio paths are not corrected in Merge Animator

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#587] NDMF plugins that modify animators would cause AnimatorLayerControl behaviors to be lost
+- [#588] Animator Play Audio paths are not correctly remapped in Merge Animator
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#587] NDMF plugins that modify animators would cause AnimatorLayerControl behaviors to be lost
+- [#588] Animator Play Audio paths are not correctly remapped in Merge Animator
 
 ### Changed
 

--- a/Editor/API/AnimatorServices/VirtualControllerContext.cs
+++ b/Editor/API/AnimatorServices/VirtualControllerContext.cs
@@ -257,8 +257,9 @@ namespace nadena.dev.ndmf.animator
 
                     if (basePath != "")
                     {
-                        new AnimationIndex(new[] { vc })
-                            .ApplyPathPrefix(basePath);
+                        var index = new AnimationIndex(new[] { vc });
+                        index.PlatformBindings = _platformBindings;
+                        index.ApplyPathPrefix(basePath);
                     }
                 }
             }

--- a/Runtime/TestSupport/VirtualizedComponent.cs
+++ b/Runtime/TestSupport/VirtualizedComponent.cs
@@ -7,11 +7,18 @@ namespace nadena.dev.ndmf.UnitTestSupport
 {
     internal class VirtualizedComponent : MonoBehaviour, IVirtualizeAnimatorController
     {
+        public string MotionBasePath { get; set; } = "";
         public RuntimeAnimatorController AnimatorController { get; set; }
 
         public string GetMotionBasePath(object ndmfBuildContext, bool clearPath = true)
         {
-            return "";
+            var result = MotionBasePath;
+            if (clearPath)
+            {
+                MotionBasePath = "";
+            }
+
+            return result;
         }
 
         public object? TargetControllerKey { get; set; } = null;

--- a/UnitTests~/AnimationServices/VRChatTests.cs
+++ b/UnitTests~/AnimationServices/VRChatTests.cs
@@ -256,6 +256,31 @@ namespace UnitTests.AnimationServices
             Assert.AreEqual("B", behaviour.SourcePath);
         }
 
+        [Test]
+        public void RemapPlayAudioPaths_InVirtualizedController()
+        {
+            var root = CreateRoot("root");
+            var ac = LoadAsset<AnimatorController>("TestAssets/PlayAudio/playaudio_ac.controller");
+
+            var sub = CreateChild(root, "B");
+            var audio = CreateChild(sub, "A");
+
+            var virtualized = sub.AddComponent<VirtualizedComponent>();
+            virtualized.AnimatorController = ac;
+            virtualized.MotionBasePath = "B";
+            
+            var ctx = CreateContext(root);
+            var vcc = ctx.ActivateExtensionContext<VirtualControllerContext>();
+
+            var virtualController = vcc.Controllers[virtualized];
+            var stateMachine = virtualController.Layers.First().StateMachine;
+            var state = stateMachine.DefaultState;
+            
+            var behaviour = (VRCAnimatorPlayAudio) state.Behaviours.First();
+            
+            Assert.AreEqual("B/A", behaviour.SourcePath);
+        }
+        
         private AnimatorController BuildInterlayerController(string prefix)
         {
             var ac = new AnimatorController();


### PR DESCRIPTION
Closes: https://github.com/bdunderscore/modular-avatar/issues/1549