### PR TITLE
fix: curves with paths rewritten multiple times might be deleted

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to be ignored.
 - [#591] Fixed a benign `NullReferenceException` at initialization
 - [#595] Fixed a NullReferenceException in AnimationIndex
+- [#598] Fixed an issue where animation curve paths being rewritten multiple times might be deleted
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#597] Fixed an issue where duplicate layer entries in the VRChat Avatar Descriptor would cause all animator contents
   to be ignored.
 - [#591] Fixed a benign `NullReferenceException` at initialization
-- [#595] Fixed a NullReferenceException in AnimationIndex 
+- [#595] Fixed a NullReferenceException in AnimationIndex
+- [#598] Fixed an issue where animation curve paths being rewritten multiple times might be deleted
 
 ### Changed
 

--- a/UnitTests~/AnimationServices/VirtualClipTest.cs
+++ b/UnitTests~/AnimationServices/VirtualClipTest.cs
@@ -304,6 +304,42 @@ namespace UnitTests.AnimationServices
             Assert.AreEqual(42, curve.keys[0].value);
         }
 #endif
+
+        [Test]
+        public void MultiplePathRewrites()
+        {
+            var clip = VirtualClip.Create("test");
+            clip.SetFloatCurve("abc", typeof(GameObject), "m_IsActive", new AnimationCurve(new Keyframe(0, 0), new Keyframe(1, 1)));
+            
+            clip.EditPaths(p => p + "1");
+            clip.EditPaths(p => p + "2");
+            clip.EditPaths(p => p + "3");
+            
+            var bindings = clip.GetFloatCurveBindings().ToList();
+            Assert.AreEqual(1, bindings.Count);
+            Assert.AreEqual("abc123", bindings[0].path);
+            Assert.AreEqual(typeof(GameObject), bindings[0].type);
+            Assert.AreEqual("m_IsActive", bindings[0].propertyName);
+            Assert.AreEqual(2, clip.GetFloatCurve("abc123", typeof(GameObject), "m_IsActive")!.keys.Length);
+        }
+        
+        [Test]
+        public void MultiplePathRewrites_WithOverride()
+        {
+            var clip = VirtualClip.Create("test");
+            clip.SetFloatCurve("abc", typeof(GameObject), "m_IsActive", new AnimationCurve(new Keyframe(0, 0), new Keyframe(1, 1)));
+            
+            clip.EditPaths(_ => "1");
+            clip.EditPaths(_ => "2");
+            clip.EditPaths(_ => "abc123");
+            
+            var bindings = clip.GetFloatCurveBindings().ToList();
+            Assert.AreEqual(1, bindings.Count);
+            Assert.AreEqual("abc123", bindings[0].path);
+            Assert.AreEqual(typeof(GameObject), bindings[0].type);
+            Assert.AreEqual("m_IsActive", bindings[0].propertyName);
+            Assert.AreEqual(2, clip.GetFloatCurve("abc123", typeof(GameObject), "m_IsActive")!.keys.Length);
+        }
         
         [Test]
         public void PreservesAdditiveReferencePose()


### PR DESCRIPTION
Previously, VirtualClip tried to track the modified state on a
curve-by-curve basis. This was meant to be an optimization to avoid
having to rewrite all curves when only some were modified, but
unfortunately due to weird Unity bugs, it turned out to be necessary to
always clear the clip and write all curves, making this tracking a bit
vestigial.

In some cases, the cached curves used to mark "deleted" curves would be
further rewritten if path rewriting happened multiple times, which could
end up overwriting (and deleting) a curve which should be retained.

This change removes this vestigial dirty tracking to remove this issue
and simplify the implementation overall.
