### PR TITLE
fix: substate machine transitions are not enumerated

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#599] Substate machine transitions were not being enumerated (and thus not processed for MA Parameters renaming)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - These components are very much subject to change in future builds (and are hidden behind the NDMF_EXPERIMENTAL feature flag)
 
 ### Fixed
+- [#599] Substate machine transitions were not being enumerated (and thus not processed for MA Parameters renaming)
 
 ### Changed
 

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualStateMachine.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualStateMachine.cs
@@ -264,6 +264,14 @@ namespace nadena.dev.ndmf.animator
             {
                 yield return transition;
             }
+
+            foreach (var kv in StateMachineTransitions)
+            {
+                foreach (var t in kv.Value)
+                {
+                    yield return t;
+                }
+            }
         }
 
         public VirtualState AddState(string name, VirtualMotion? motion = null, Vector3? position = null)
@@ -308,7 +316,8 @@ namespace nadena.dev.ndmf.animator
                     }
                 }
             }
-
         }
+        
+        
     }
 }

--- a/UnitTests~/AnimationServices/VirtualStateMachineTest.cs
+++ b/UnitTests~/AnimationServices/VirtualStateMachineTest.cs
@@ -151,6 +151,33 @@ namespace UnitTests.AnimationServices
             
             Assert.IsTrue(vsm.AllStates().Any(s => s.Name == "x"));
         }
+
+        [Test]
+        public void AllReachableNodesEnumeratesSubstateMachineTransitions()
+        {
+            var sm = TrackObject(new AnimatorStateMachine());
+            var sm2 = TrackObject(new AnimatorStateMachine());
+            
+            sm.stateMachines = new[]
+            {
+                new ChildAnimatorStateMachine() { stateMachine = sm2 }
+            };
+            
+            sm.SetStateMachineTransitions(sm2, new AnimatorTransition[]
+            {
+                new AnimatorTransition()
+                {
+                    name = "test",
+                    isExit = true,
+                }
+            });
+            
+            var cloneContext = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+            var vsm = cloneContext.Clone(sm);
+
+            var node = vsm.AllReachableNodes().OfType<VirtualTransitionBase>().First();
+            Assert.AreEqual("test", node.Name);
+        }
     }
     
    


### PR DESCRIPTION
Related: https://github.com/bdunderscore/modular-avatar/issues/1559
