### PR TITLE
fix: certain VirtualClip methods could attempt to modify proxy clips

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#602] Fix issue where, if the hidden "mask" value on the gesture layer in the VRChat avatar controller was missing,
   the avatar would be stuck in "bicycle pose" in gesture manager and Av3Emulator.
+- [#604] Fix an issue where certain VirtualClip properties could attempt to modify VRChat proxy animation clips.
+- [#604] Fix `VirtualClip.AdditiveReferencePoseTime` setter not working
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#602] Fix issue where, if the hidden "mask" value on the gesture layer in the VRChat avatar controller was missing,
   the avatar would be stuck in "bicycle pose" in gesture manager and Av3Emulator.
+- [#604] Fix an issue where certain VirtualClip properties could attempt to modify VRChat proxy animation clips.
+- [#604] Fix `VirtualClip.AdditiveReferencePoseTime` setter not working
 
 ### Changed
 

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualClip.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualClip.cs
@@ -23,7 +23,10 @@ namespace nadena.dev.ndmf.animator
         public override string Name
         {
             get => _clip.name;
-            set => _clip.name = I(value);
+            set
+            {
+                if (!IsMarkerClip) _clip.name = I(value);
+            }
         }
 
         /// <summary>
@@ -53,13 +56,19 @@ namespace nadena.dev.ndmf.animator
         public bool Legacy
         {
             get => _clip.legacy;
-            set => _clip.legacy = I(value);
+            set
+            {
+                if (!IsMarkerClip) _clip.legacy = I(value);
+            }
         }
 
         public Bounds LocalBounds
         {
             get => _clip.localBounds;
-            set => _clip.localBounds = I(value);
+            set
+            {
+                if (!IsMarkerClip) _clip.localBounds = I(value);
+            }
         }
 
         public AnimationClipSettings Settings
@@ -72,6 +81,8 @@ namespace nadena.dev.ndmf.animator
                     throw new ArgumentException("Use the AdditiveReferencePoseClip property instead",
                         nameof(value.additiveReferencePoseClip));
                 }
+
+                if (IsMarkerClip) return;
 
                 AnimationUtility.SetAnimationClipSettings(_clip, value);
             }
@@ -92,20 +103,28 @@ namespace nadena.dev.ndmf.animator
             {
                 var settings = Settings;
                 settings.additiveReferencePoseTime = I(value);
-                Settings = settings;
+                if (!IsMarkerClip) AnimationUtility.SetAnimationClipSettings(_clip, settings);
             }
         }
 
         public WrapMode WrapMode
         {
             get => _clip.wrapMode;
-            set => _clip.wrapMode = I(value);
+            set
+            {
+                if (IsMarkerClip) return;
+                _clip.wrapMode = I(value);
+            }
         }
 
         public float FrameRate
         {
             get => _clip.frameRate;
-            set => _clip.frameRate = I(value);
+            set
+            {
+                if (IsMarkerClip) return;
+                _clip.frameRate = I(value);
+            }
         }
 
         private Dictionary<EditorCurveBinding, CachedCurve<AnimationCurve>> _curveCache = new(ECBComparator.Instance);

--- a/UnitTests~/AnimationServices/VirtualClipTest.cs
+++ b/UnitTests~/AnimationServices/VirtualClipTest.cs
@@ -413,6 +413,43 @@ namespace UnitTests.AnimationServices
             
             Assert.AreEqual(loopTime, settings.loopTime);
         }
+
+        [Test]
+        public void MarkerClipConfigurationIsPreserved()
+        {
+            var markerClip = TrackObject(new AnimationClip());
+            markerClip.name = "m1";
+            markerClip.legacy = false;
+            markerClip.localBounds = new Bounds(Vector3.zero, Vector3.one);
+            markerClip.wrapMode = WrapMode.Loop;
+            markerClip.frameRate = 60;
+            
+            var ref1 = TrackObject(new AnimationClip());
+            var ref2 = TrackObject(new AnimationClip());
+
+            AnimationClipSettings settings = new AnimationClipSettings();
+            settings.additiveReferencePoseClip = ref1;
+            settings.additiveReferencePoseTime = 0;
+            AnimationUtility.SetAnimationClipSettings(markerClip, settings);
+
+            var vc = VirtualClip.FromMarker(markerClip);
+            vc.Name = "notamarker";
+            vc.Legacy = true;
+            vc.LocalBounds = new Bounds(Vector3.one, Vector3.one * 2);
+            vc.AdditiveReferencePoseClip = VirtualClip.FromMarker(ref2);
+            vc.AdditiveReferencePoseTime = 123;
+            vc.WrapMode = WrapMode.PingPong;
+            vc.FrameRate = 123;
+            
+            // Original clip is unchanged
+            Assert.AreEqual("m1", markerClip.name);
+            Assert.IsFalse(markerClip.legacy);
+            Assert.AreEqual(new Bounds(Vector3.zero, Vector3.one), markerClip.localBounds);
+            Assert.AreEqual(WrapMode.Loop, markerClip.wrapMode);
+            Assert.AreEqual(60, markerClip.frameRate);
+            Assert.AreEqual(ref1, AnimationUtility.GetAnimationClipSettings(markerClip).additiveReferencePoseClip);
+            Assert.AreEqual(0, AnimationUtility.GetAnimationClipSettings(markerClip).additiveReferencePoseTime);
+        }
         
         // TODO: animation clip settings/misc properties tests
 


### PR DESCRIPTION
This also fixes the AdditiveReferencePoseTime property not working on VirtualClip.
