### PR TITLE
fix: KeyException when synced layer's base layer states are deleted

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Experimental: Added UI to enable/disable experimental features
 
 ### Fixed
+- [#626] Fixed an issue where an exception would be thrown if the base state corresponding to a synced layer override is destroyed.
 - VRChat build hooks did not run certain NDMF passes (in newly added build phases)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Experimental: Added Portable Dynamic Bone Collider component
 
 ### Fixed
+- [#626] Fixed an issue where an exception would be thrown if the base state corresponding to a synced layer override is destroyed.
 - [#607] Fixed an issue where zh-Hans l10n text fallback to zh-Hant.
 
 ### Changed

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualLayer.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualLayer.cs
@@ -142,7 +142,8 @@ namespace nadena.dev.ndmf.animator
             _stateMachine = context.Clone(layer.stateMachine);
 
             _syncedLayerMotionOverrides = SyncedLayerOverrideAccess.ExtractStateMotionPairs(layer)
-                                              ?.ToImmutableDictionary(kvp => context.Clone(kvp.Key),
+                                              ?.Where(kvp => kvp.Key).ToImmutableDictionary(
+                                                  kvp => context.Clone(kvp.Key),
                                                   kvp => context.Clone(kvp.Value))
                                           ?? ImmutableDictionary<VirtualState, VirtualMotion>.Empty;
 

--- a/UnitTests~/AnimationServices/VirtualLayerTest.cs
+++ b/UnitTests~/AnimationServices/VirtualLayerTest.cs
@@ -153,6 +153,25 @@ namespace UnitTests.AnimationServices
         }
         
         [Test]
+        public void DeletedSyncedLayerOverridesAreExcluded()
+        {
+            var testController = LoadAsset<AnimatorController>("TestAssets/SyncedLayers.controller");
+            var context = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+            var virtualController = context.Clone(testController);
+            
+            // First, clone the test controller
+            var commitContext = new CommitContext();
+            var committed = commitContext.CommitObject(virtualController);
+            
+            // Destroy the base state and reload the controller
+            UnityEngine.Object.DestroyImmediate(committed.layers[0].stateMachine.defaultState);
+            
+            context = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+            // Shouldn't throw an exception
+            context.Clone(committed);
+        }
+        
+        [Test]
         public void SyncedLayerOverridesCanBeChanged()
         {
             var testController = LoadAsset<AnimatorController>("TestAssets/SyncedLayers.controller");


### PR DESCRIPTION
Closes: https://github.com/bdunderscore/modular-avatar/issues/1577
