### PR TITLE
feat: no alloc overload for `ComputeContext.GetComponentsXXX`

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [#644] No alloc overload for `ComputeContext.GetComponentsXXX`
 
 ### Fixed
 - [#642] NDMFViewpoint was handled incorrectly in avatars with a scaled avatar root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added Portable Dynamic Bone component
   - Added Portable Dynamic Bone Collider component
 
+- [#644] No alloc overload for `ComputeContext.GetComponentsXXX`
+
 ### Fixed
 - [#634] Avoid infinite recursion if an avatar is duplicated during play mode activation
 

--- a/Editor/PreviewSystem/ComputeContext/SingleObjectQueries.cs
+++ b/Editor/PreviewSystem/ComputeContext/SingleObjectQueries.cs
@@ -278,6 +278,18 @@ namespace nadena.dev.ndmf.preview
             return obj.GetComponents<C>();
         }
 
+        public static void GetComponents<C>(this ComputeContext ctx, GameObject obj, List<C> results,
+            [CallerFilePath] string callerPath = "",
+            [CallerLineNumber] int callerLine = 0
+        ) where C : class
+        {
+            if (obj == null) return;
+
+            ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, false);
+
+            obj.GetComponents(results);
+        }
+
         public static Component[] GetComponents(this ComputeContext ctx, GameObject obj, Type type,
             [CallerFilePath] string callerPath = "",
             [CallerLineNumber] int callerLine = 0
@@ -288,6 +300,17 @@ namespace nadena.dev.ndmf.preview
             ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, false);
 
             return obj.GetComponents(type);
+        }
+
+        public static void GetComponents(this ComputeContext ctx, GameObject obj, Type type, List<Component> results,
+            [CallerFilePath] string callerPath = "",
+            [CallerLineNumber] int callerLine = 0
+        )
+        {
+            if (obj == null) return;
+
+            ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, false);
+            obj.GetComponents(type, results);
         }
 
         public static C[] GetComponentsInChildren<C>(this ComputeContext ctx, GameObject obj, bool includeInactive,
@@ -301,6 +324,19 @@ namespace nadena.dev.ndmf.preview
             ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, true);
 
             return obj.GetComponentsInChildren<C>(includeInactive);
+        }
+
+        public static void GetComponentsInChildren<C>(this ComputeContext ctx, GameObject obj, bool includeInactive, List<C> results,
+            [CallerFilePath] string callerPath = "",
+            [CallerLineNumber] int callerLine = 0
+        )
+            where C : class
+        {
+            if (obj == null) return;
+
+            ObjectWatcher.Instance.MonitorGetComponents(obj, ctx, true);
+
+            obj.GetComponentsInChildren(includeInactive, results);
         }
 
         public static Component[] GetComponentsInChildren(this ComputeContext ctx, GameObject obj, Type type,


### PR DESCRIPTION
Add no alloc overload for `ComputeContext.GetComponentsXXX`.