### PR TITLE
fix: Missing dependency to Animation module

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#655] Missing dependency to Animation module
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#634] Avoid infinite recursion if an avatar is duplicated during play mode activation
+- [#655] Missing dependency to Animation module
 
 ### Changed
 - [#635] The `IVirtualizeMotion.Motion` and `IVirtualizeAnimatorController.AnimatorController` properties now have a nullable type.

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "name": "bd_",
     "email": "bd_@nadena.dev",
     "url": "https://github.com/bdunderscore/ndmf"
+  },
+  "dependencies": {
+    "com.unity.modules.animation": "1.0.0"
   }
 }


### PR DESCRIPTION
If NDMF package was installed to project without any built-in module installed, the following compile error will be appear.
> Packages/nadena.dev.ndmf/Runtime/API/IVirtualizeAnimatorController.cs(20,16): error CS1069: The type name 'RuntimeAnimatorController' could not be found in the namespace 'UnityEngine'. This type has been forwarded to assembly 'UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' Consider adding a reference to that assembly.

> Packages/nadena.dev.ndmf/Runtime/TestSupport/VirtualizedComponent.cs(11,16): error CS1069: The type name 'RuntimeAnimatorController' could not be found in the namespace 'UnityEngine'. This type has been forwarded to assembly 'UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' Consider adding a reference to that assembly.

> Packages/nadena.dev.ndmf/Runtime/API/IVirtualizeMotion.cs(22,16): error CS1069: The type name 'Motion' could not be found in the namespace 'UnityEngine'. This type has been forwarded to assembly 'UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' Consider adding a reference to that assembly.