### PR TITLE
Fix comparison function of `SingleObjectQuery.ObserveTransformPosition`

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#675] Fixed comparison function in `SingleObjectQuery.ObserveTransformPosition`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#675] Fixed comparison function in `SingleObjectQuery.ObserveTransformPosition`
 
 ### Changed
 

--- a/Editor/PreviewSystem/ComputeContext/SingleObjectQueries.cs
+++ b/Editor/PreviewSystem/ComputeContext/SingleObjectQueries.cs
@@ -192,9 +192,9 @@ namespace nadena.dev.ndmf.preview
             {
                 ctx.Observe(node, obj => (obj.localPosition, obj.localRotation, obj.localScale), (a, b) =>
                 {
-                    return Vector3.Distance(a.Item1, b.Item1) > 0.0001f ||
-                           Quaternion.Angle(a.Item2, b.Item2) > 0.0001f ||
-                           Vector3.Distance(a.Item3, b.Item3) > 0.0001f;
+                    return Vector3.Distance(a.Item1, b.Item1) <= 0.0001f &&
+                           Quaternion.Angle(a.Item2, b.Item2) <= 0.0001f &&
+                           Vector3.Distance(a.Item3, b.Item3) <= 0.0001f;
                 });
             }
 


### PR DESCRIPTION
Current comparison function of `SingleObjectQuery.ObserveTransformPosition` returns inverted value, so that observing any Transform by this function causes update in every frame.