### PR TITLE
Prefer `label` property over `text` in UIElementLocalizer

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Changed
+- [#690] Now `UIElementLocalizer` prefers `label` property over `text` property
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Changed
+- [#690] Now `UIElementLocalizer` prefers `label` property over `text` property
 
 ### Removed
 

--- a/Editor/UI/Localization/UIElementLocalizer.cs
+++ b/Editor/UI/Localization/UIElementLocalizer.cs
@@ -52,7 +52,7 @@ namespace nadena.dev.ndmf.localization
         {
             if (!_localizers.TryGetValue(ty, out var action))
             {
-                PropertyInfo m_label = ty.GetProperty("text") ?? ty.GetProperty("label");
+                PropertyInfo m_label = ty.GetProperty("label") ?? ty.GetProperty("text");
                
                 if (m_label == null)
                 {


### PR DESCRIPTION
* Some components like [`DropdownField`](https://docs.unity3d.com/2022.3/Documentation/ScriptReference/UIElements.DropdownField.html) have both `label` and `text`.
* Localizing `DropdownField` by this method will throw an exception because the `text` property is getter-only.
    - In this situation, the `label` property should be localized.
* As far as I tested, reversing the preference of these properties resolves this issue.