### PR TITLE
Add `NDMFPreview.GetProxyObjectForOriginal` method

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Expose `NormalizedBlendValues` from `VirtualBlendTree`
+- [#691] Added `NDMFPreview.GetProxyObjectForOriginal` as complement of existing method
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Expose `NormalizedBlendValues` from `VirtualBlendTree`
+- [#691] Added `NDMFPreview.GetProxyObjectForOriginal` as complement of existing method
 
 ### Fixed
 

--- a/Editor/PreviewSystem/NDMFPreview.cs
+++ b/Editor/PreviewSystem/NDMFPreview.cs
@@ -116,5 +116,22 @@ namespace nadena.dev.ndmf.preview
 
             return sess.ProxyToOriginalObject.GetValueOrDefault(proxy);
         }
+
+        /// <summary>
+        /// If the given game object has a preview proxy object, returns it.
+        /// </summary>
+        /// <param name="original">The suspected original object</param>
+        /// <returns>The proxy object, or null if the given object does not have a proxy</returns>
+        public static GameObject? GetProxyObjectForOriginal(GameObject original)
+        {
+            var sess = PreviewSession.Current;
+
+            if (sess == null)
+            {
+                return null;
+            }
+
+            return sess.OriginalToProxyObject.GetValueOrDefault(original);
+        }
     }
 }


### PR DESCRIPTION
`GetComponent` in custom insepctor returns the original GameObject.
This PR adds inverse of existing `NDMFPreview.GetProxyObjectForOriginal`.