### PR TITLE
fix: mesh preview fails on readonly meshes

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#675] Fixed comparison function in `SingleObjectQuery.ObserveTransformPosition`
+- [#692] Fixed issues where mesh manipulation would fail on readonly meshes, potentially breaking the preview system
+  entirely.
 
 ### Changed
 - [#690] Now `UIElementLocalizer` prefers `label` property over `text` property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#675] Fixed comparison function in `SingleObjectQuery.ObserveTransformPosition`
+- [#692] Fixed issues where mesh manipulation would fail on readonly meshes, potentially breaking the preview system
+entirely.
 
 ### Changed
 - [#690] Now `UIElementLocalizer` prefers `label` property over `text` property


### PR DESCRIPTION
Normally, Unity allows editor scripts to access readonly mesh data.
However, this specifically only applies to editor callback functions -
NDMF was running things in the Unity synchronization context, which was
not considered an editor callback. To work around this, we now perform
NDMFSyncContext processing in the editor update callback, which should
fix it for all preview plugins.
