### PR TITLE
fix: adjust parameter drivers when parameter types are changed

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entirely.
 
 ### Changed
+- [#693] `VirtualAnimatorController` will adjust VRChat parameter drivers to preserve behavior when parameter types are changed
+- [#693] `VirtualAnimatorController.Parameters` will now clone `AnimatorControllerParameter` objects on get and set.
 - [#690] Now `UIElementLocalizer` prefers `label` property over `text` property
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 entirely.
 
 ### Changed
+
+- [#693] `VirtualAnimatorController` will adjust VRChat parameter drivers to preserve behavior when parameter types are changed
+- [#693] `VirtualAnimatorController.Parameters` will now clone `AnimatorControllerParameter` objects on get and set.
 - [#690] Now `UIElementLocalizer` prefers `label` property over `text` property
 
 ### Removed

--- a/Editor/API/AnimatorServices/PlatformBindings/IPlatformAnimatorBindings.cs
+++ b/Editor/API/AnimatorServices/PlatformBindings/IPlatformAnimatorBindings.cs
@@ -84,5 +84,18 @@ namespace nadena.dev.ndmf.animator
         void RemapPathsInStateBehaviour(StateMachineBehaviour behaviour, Func<string, string?> remapPath)
         {
         }
+
+        /// <summary>
+        ///     Invoked when the type of an existing parameter is changed. This is used in the VRChat bindings to
+        ///     adjust parameter drivers when a parameter is changed from bool to float, in order to preserve behavior.
+        /// </summary>
+        /// <param name="controller">The controller that was modified</param>
+        /// <param name="changes">A map of (parameter name, old type, new type)</param>
+        void OnParameterTypeChanges(
+            VirtualAnimatorController controller,
+            IEnumerable<(string, AnimatorControllerParameterType, AnimatorControllerParameterType)> changes
+        )
+        {
+        }
     }
 }

--- a/Editor/API/Util/GlobalTransformations.cs
+++ b/Editor/API/Util/GlobalTransformations.cs
@@ -81,10 +81,14 @@ namespace nadena.dev.ndmf.util
 
             foreach (var controller in controllers)
             {
+                var newParams = controller.Parameters;
                 foreach (var (name, acp) in controller.Parameters)
                 {
                     acp.type = parameterTypes[name];
+                    newParams = newParams.SetItem(name, acp);
                 }
+
+                controller.Parameters = newParams;
 
                 foreach (var node in controller.AllReachableNodes())
                 {

--- a/UnitTests~/AnimationServices/TypeAdjustment/ConvertTransitionTypes.cs
+++ b/UnitTests~/AnimationServices/TypeAdjustment/ConvertTransitionTypes.cs
@@ -31,6 +31,7 @@ public class ConvertTransitionTypes : TestBase
                     if (existing.type != v.type)
                     {
                         existing.type = AnimatorControllerParameterType.Float;
+                        vac.Parameters = vac.Parameters.SetItem(k, existing);
                     }
                 }
                 else

--- a/UnitTests~/AnimationServices/VirtualAnimatorControllerTest.cs
+++ b/UnitTests~/AnimationServices/VirtualAnimatorControllerTest.cs
@@ -49,6 +49,20 @@ namespace UnitTests.AnimationServices
         }
 
         [Test]
+        public void ParametersAreImmutable()
+        {
+            CloneContext context = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+            
+            var controller = TrackObject(new AnimatorController());
+            controller.AddParameter("x", AnimatorControllerParameterType.Bool);
+            
+            var virtualController = context.Clone(controller);
+            virtualController.Parameters["x"].type = AnimatorControllerParameterType.Float;
+            
+            Assert.AreEqual(AnimatorControllerParameterType.Bool, virtualController.Parameters["x"].type);
+        }
+
+        [Test]
         public void HandlesNullStateMachineReferences()
         {
             CloneContext context = new CloneContext(GenericPlatformAnimatorBindings.Instance);


### PR DESCRIPTION
Needed for bdunderscore/modular-avatar#1725 (doesn't fix it quite yet, that requires more changes on the MA side)
