### PR TITLE
fix: Fix converting non-VRChat avatars into VRChat avatars creating incomplete VRCAvatarDescriptors

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#702] Converting non-VRChat platform avatars to VRChat resulted in incompletely initialized avatar descriptors.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#675] Fixed comparison function in `SingleObjectQuery.ObserveTransformPosition`
 - [#692] Fixed issues where mesh manipulation would fail on readonly meshes, potentially breaking the preview system
 entirely.
+- [#702] Converting non-VRChat platform avatars to VRChat resulted in incompletely initialized avatar descriptors.
 
 ### Changed
 - [#693] `VirtualAnimatorController` will adjust VRChat parameter drivers to preserve behavior when parameter types are changed

--- a/Editor/VRChat/VRChatPlatform.cs
+++ b/Editor/VRChat/VRChatPlatform.cs
@@ -78,6 +78,8 @@ namespace nadena.dev.ndmf.vrchat
             if (!avatarRoot.TryGetComponent<VRCAvatarDescriptor>(out var vrcAvDesc))
             {
                 vrcAvDesc = avatarRoot.AddComponent<VRCAvatarDescriptor>();
+                // Initialize array SerializeFields with empty array instances
+                EditorUtility.CopySerialized(vrcAvDesc, vrcAvDesc);
             }
 
             if (cai.EyePosition != null)


### PR DESCRIPTION
Currently, an Apply on Play would convert a non-VRChat avatar with any of the defined avatar root components into a VRChat avatar.

This conversion results in incompletely initialized VRCAvatarDescriptor component for arrays like `baseAnimationLayers`, and may confuse some NDMF plugins.