### PR TITLE
fix: Preview trace buttons height

### DIFF
--- a/Editor/PreviewSystem/Trace/TraceWindow.uss
+++ b/Editor/PreviewSystem/Trace/TraceWindow.uss
@@ -20,6 +20,7 @@ ScrollView Foldout {
 }
 
 #buttons {
+    flex-shrink: 0;
     flex-direction: row;
     justify-content: space-between;
 }


### PR DESCRIPTION
Before:

<img width="873" height="394" alt="before fix" src="https://github.com/user-attachments/assets/4bc04616-147d-442e-9f55-d46f6958a4f1" />

After:

<img width="873" height="394" alt="fixed" src="https://github.com/user-attachments/assets/baa97420-73cb-4c90-a607-e5565c3f7814" />