### PR TITLE
fix: deduplicate results in `ComputeContext.GetAvatarRoots()`

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#766] Deduplicate results in `ComputeContext.GetAvatarRoots()`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ memoization and caching.
 - [#733] Improve preview system performance
 - [#734] Sometimes, `ComputeContext.FlushInvalidates` would not reliably flush all pending invalidate calls
 - [#737] Fixed an issue that occasionally resulted in errors while processing previews
-- [#740]
 
 ### Changed
 - [#733] `ComputeContext.GetAvatarRoots` will now return only active-in-hierarchy avatar roots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#766] Deduplicate results in `ComputeContext.GetAvatarRoots()`
 
 ### Changed
 
@@ -50,6 +51,7 @@ memoization and caching.
 - [#733] Improve preview system performance
 - [#734] Sometimes, `ComputeContext.FlushInvalidates` would not reliably flush all pending invalidate calls
 - [#737] Fixed an issue that occasionally resulted in errors while processing previews
+- [#740]
 
 ### Changed
 - [#733] `ComputeContext.GetAvatarRoots` will now return only active-in-hierarchy avatar roots

--- a/Editor/PreviewSystem/ComputeContext/GlobalQueries.cs
+++ b/Editor/PreviewSystem/ComputeContext/GlobalQueries.cs
@@ -71,7 +71,7 @@ namespace nadena.dev.ndmf.preview
 
         public static ImmutableList<GameObject> GetAvatarRoots(this ComputeContext ctx)
         {
-            return AVATAR_ROOTS.Get(ctx, AVATAR_ROOTS);
+            return AVATAR_ROOTS.Get(ctx, AVATAR_ROOTS).Distinct().ToImmutableList();
         }
     }
 }

--- a/Editor/PreviewSystem/ComputeContext/GlobalQueries.cs
+++ b/Editor/PreviewSystem/ComputeContext/GlobalQueries.cs
@@ -26,7 +26,7 @@ namespace nadena.dev.ndmf.preview
                         // (parent components may affect avatar rootness) 
                         ObjectWatcher.Instance.MonitorGetComponents(root, ctx, true);
                         return RuntimeUtil.FindAvatarRoots(root, true);
-                    });
+                    }).Distinct();
 
                     return components.Where(c => ctx.ActiveInHierarchy(c)).ToImmutableList();
                 },
@@ -71,7 +71,7 @@ namespace nadena.dev.ndmf.preview
 
         public static ImmutableList<GameObject> GetAvatarRoots(this ComputeContext ctx)
         {
-            return AVATAR_ROOTS.Get(ctx, AVATAR_ROOTS).Distinct().ToImmutableList();
+            return AVATAR_ROOTS.Get(ctx, AVATAR_ROOTS);
         }
     }
 }


### PR DESCRIPTION
fix: #765