### PR TITLE
chore: Improved target acquisition performance in preview.

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#766] Deduplicate results in `ComputeContext.GetAvatarRoots()`
 
 ### Changed
+- [#775] Improve target acquisition performance in preview.
 
 ### Removed
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [#775] Add Optional KeyComparer argument to `PropCache`.
 
 ### Fixed
 - [#766] Deduplicate results in `ComputeContext.GetAvatarRoots()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [#775] Add Optional KeyComparer argument to `PropCache`.
 
 ### Fixed
 - [#766] Deduplicate results in `ComputeContext.GetAvatarRoots()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#766] Deduplicate results in `ComputeContext.GetAvatarRoots()`
 
 ### Changed
+- [#775] Improve target acquisition performance in preview.
 
 ### Removed
 

--- a/Editor/PreviewSystem/ComputeContext/PropCache.cs
+++ b/Editor/PreviewSystem/ComputeContext/PropCache.cs
@@ -81,7 +81,7 @@ namespace nadena.dev.ndmf.preview
         private readonly string _debugName;
         private readonly Func<ComputeContext, TKey, TValue> _operator;
         private readonly Func<TValue, TValue, bool>? _equalityComparer;
-        private readonly Dictionary<TKey, CacheEntry> _cache = new();
+        private readonly Dictionary<TKey, CacheEntry> _cache;
 
         // This is used only for debugging purposes to identify when the propcache is regenerated,
         // we don't mind it not being shared across different instantiations.
@@ -98,15 +98,20 @@ namespace nadena.dev.ndmf.preview
         ///     result. If this function returns true, then downstream consumers will not be invalidated. Note that if the
         ///     equality comparator is present, the function may be re-evaluated multiple times per cache invalidation.
         /// </param>
+        /// <param name="keyComparer">
+        ///     Optional comparer used for cache keys. If null, EqualityComparer<TKey>.Default is used.
+        /// </param>
         public PropCache(
             string debugName,
             Func<ComputeContext, TKey, TValue> operatorFunc,
-            Func<TValue, TValue, bool>? equalityComparer = null
+            Func<TValue, TValue, bool>? equalityComparer = null,
+            IEqualityComparer<TKey>? keyComparer = null
         )
         {
             _debugName = debugName;
             _operator = operatorFunc;
             _equalityComparer = equalityComparer;
+            _cache = new Dictionary<TKey, CacheEntry>(keyComparer ?? EqualityComparer<TKey>.Default);
 
             WeakReference<PropCache<TKey, TValue>> selfRef = new(this);
             PropCacheDebug.InternalRegister(this, () =>

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -64,11 +64,12 @@ namespace nadena.dev.ndmf.preview
         /// <summary>
         /// Attaches data to this render group and provides explicit equality for RenderGroup identity.
         /// The supplied equality defines when two groups should be treated as the same for preview purposes,
-        /// including node reuse and cached target-group retention. Any mutable state that affects preview output should
-        /// be tracked through ComputeContext observation.
+        /// including cached target-group retention and node reuse.
         /// </summary>
         public RenderGroup WithData<T>(T data, Func<T, T, bool> equals, Func<T, int> getHashCode = null)
         {
+            // We take delegates instead of IEqualityComparer<T> because RenderGroup equality also needs a stable
+            // equality contract for the comparer itself.
             return new RenderGroup<T>(Renderers, DebugNames, data, new DelegateEqualityComparer<T>(equals, getHashCode));
         }
 

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -5,7 +5,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using UnityEngine;
@@ -52,26 +51,9 @@ namespace nadena.dev.ndmf.preview
             );
         }
 
-        /// <summary>
-        /// Attaches data to this render group.
-        /// This overload participates in RenderGroup equality using heuristic comparison rules.
-        /// To avoid heuristic comparison, use the explicit equality overload instead.
-        /// </summary>
         public RenderGroup WithData<T>(T data)
         {
-            return new RenderGroup<T>(Renderers, DebugNames, data, HeuristicContextEqualityComparer<T>.Instance);
-        }
-
-        /// <summary>
-        /// Attaches data to this render group and provides explicit equality for RenderGroup identity.
-        /// The supplied equality defines when two groups should be treated as the same for preview purposes,
-        /// including cached target-group retention and node reuse.
-        /// </summary>
-        public RenderGroup WithData<T>(T data, Func<T, T, bool> equals, Func<T, int> getHashCode = null)
-        {
-            // We take delegates instead of IEqualityComparer<T> because RenderGroup equality also needs a stable
-            // equality contract for the comparer itself.
-            return new RenderGroup<T>(Renderers, DebugNames, data, new DelegateEqualityComparer<T>(equals, getHashCode));
+            return new RenderGroup<T>(Renderers, DebugNames, data);
         }
 
         internal virtual RenderGroup Filter(HashSet<Renderer> activeRenderers)
@@ -124,29 +106,28 @@ namespace nadena.dev.ndmf.preview
     internal sealed class RenderGroup<T> : RenderGroup
     {
         public T Context { get; }
-        private readonly IEqualityComparer<T> _contextComparer;
 
         internal RenderGroup(ImmutableList<Renderer> renderers, ImmutableDictionary<Renderer, string> DebugNames,
-            T context, IEqualityComparer<T> contextComparer) : base(renderers, DebugNames)
+            T context) : base(renderers, DebugNames)
         {
             Context = context;
-            _contextComparer = contextComparer;
         }
         
         internal override RenderGroup Filter(HashSet<Renderer> activeRenderers)
         {
-            var filtered = Renderers.RemoveAll(r => !activeRenderers.Contains(r));
-            return new RenderGroup<T>(filtered, DebugNames, Context, _contextComparer);
+            return new RenderGroup<T>(Renderers.RemoveAll(r => !activeRenderers.Contains(r)), DebugNames, Context);
         }
         
         private bool Equals(RenderGroup<T> other)
         {
-            if (!_contextComparer.Equals(other._contextComparer))
+            if (Context is IEnumerable l && other.Context is IEnumerable ol)
             {
-                return false;
+                // This is a common mistake; List does not implement a useful Equals for us. Work around it
+                // on behalf of our consumers...
+                return base.Equals(other) && l.Cast<object>().SequenceEqual(ol.Cast<object>());
             }
-
-            return base.Equals(other) && _contextComparer.Equals(Context, other.Context);
+            
+            return base.Equals(other) && EqualityComparer<T>.Default.Equals(Context, other.Context);
         }
 
         public override bool Equals(object obj)
@@ -156,141 +137,19 @@ namespace nadena.dev.ndmf.preview
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(base.GetHashCode(), _contextComparer.GetHashCode(), _contextComparer.GetHashCode(Context));
+            if (Context is IEnumerable l)
+            {
+                return l.Cast<object>().Aggregate(base.GetHashCode(), (acc, o) => HashCode.Combine(acc, o.GetHashCode()));
+            }
+            
+            return HashCode.Combine(base.GetHashCode(), EqualityComparer<T>.Default.GetHashCode(Context));
         }
 
         internal override RenderGroup FilterLive()
         {
             if (Renderers.All(r => r != null)) return this;
 
-            var live = Renderers.Where(r => r != null).ToImmutableList();
-            return new RenderGroup<T>(live, DebugNames, Context, _contextComparer);
-        }
-    }
-
-    internal sealed class HeuristicContextEqualityComparer<T> : IEqualityComparer<T>
-    {
-        public static readonly HeuristicContextEqualityComparer<T> Instance = new();
-
-        private HeuristicContextEqualityComparer() { }
-        
-        public bool Equals(T x, T y)
-        {
-            return HeuristicEquals(x, y);
-        }
-
-        public int GetHashCode(T obj)
-        {
-            return HeuristicGetHashCode(obj);
-        }
-
-        private static bool HeuristicEquals(object x, object y)
-        {
-            if (ReferenceEquals(x, y)) return true;
-            if (x == null || y == null) return false;
-
-            if (x is ITuple tuple && y is ITuple otherTuple)
-            {
-                if (tuple.Length != otherTuple.Length) return false;
-                for (var i = 0; i < tuple.Length; i++)
-                {
-                    if (!HeuristicEquals(tuple[i], otherTuple[i])) return false;
-                }
-
-                return true;
-            }
-
-            if (x is IEnumerable enumerable && y is IEnumerable otherEnumerable)
-            {
-                var left = enumerable.GetEnumerator();
-                var right = otherEnumerable.GetEnumerator();
-
-                while (true)
-                {
-                    var leftHasNext = left.MoveNext();
-                    var rightHasNext = right.MoveNext();
-                    if (leftHasNext != rightHasNext) return false;
-                    if (!leftHasNext) return true;
-                    if (!HeuristicEquals(left.Current, right.Current)) return false;
-                }
-            }
-
-            return x.Equals(y);
-        }
-
-        private static int HeuristicGetHashCode(object obj)
-        {
-            if (obj == null) return 0;
-
-            if (obj is ITuple tuple)
-            {
-                var hash = 0;
-                for (var i = 0; i < tuple.Length; i++)
-                {
-                    hash = HashCode.Combine(hash, HeuristicGetHashCode(tuple[i]));
-                }
-
-                return hash;
-            }
-
-            if (obj is IEnumerable enumerable)
-            {
-                var hash = 0;
-                foreach (var entry in enumerable)
-                {
-                    hash = HashCode.Combine(hash, HeuristicGetHashCode(entry));
-                }
-
-                return hash;
-            }
-
-            return obj.GetHashCode();
-        }
-    }
-
-    internal sealed class DelegateEqualityComparer<T> : IEqualityComparer<T>, IEquatable<DelegateEqualityComparer<T>>
-    {
-        private readonly Func<T, T, bool> _equals;
-        private readonly Func<T, int> _getHashCode;
-
-        internal DelegateEqualityComparer(Func<T, T, bool> equals, Func<T, int> getHashCode = null)
-        {
-            _equals = equals;
-            _getHashCode = getHashCode;
-        }
-
-        public bool Equals(T x, T y)
-        {
-            if (ReferenceEquals(x, y)) return true;
-            if (x is null || y is null) return false;
-
-            return _equals(x, y);
-        }
-
-        public int GetHashCode(T obj)
-        {
-            if (obj is null) return 0;
-            return _getHashCode?.Invoke(obj) ?? 0;
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is DelegateEqualityComparer<T> other && Equals(other);
-        }
-
-        public bool Equals(DelegateEqualityComparer<T> other)
-        {
-            if (ReferenceEquals(this, other)) return true;
-            if (other is null) return false;
-            if (!_equals.Equals(other._equals)) return false;
-            if (_getHashCode is null && other._getHashCode is null) return true;
-            if (_getHashCode is null || other._getHashCode is null) return false;
-            return _getHashCode.Equals(other._getHashCode);
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(_equals, _getHashCode);
+            return new RenderGroup<T>(Renderers.Where(r => r != null).ToImmutableList(), DebugNames, Context);
         }
     }
 

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -129,7 +129,7 @@ namespace nadena.dev.ndmf.preview
             T context, IEqualityComparer<T> contextComparer = null) : base(renderers, DebugNames)
         {
             Context = context;
-            _contextComparer = contextComparer;
+            _contextComparer = contextComparer ?? HeuristicContextEqualityComparer<T>.Instance;
         }
         
         internal override RenderGroup Filter(HashSet<Renderer> activeRenderers)
@@ -140,29 +140,12 @@ namespace nadena.dev.ndmf.preview
         
         private bool Equals(RenderGroup<T> other)
         {
-            if (_contextComparer != null && other._contextComparer != null)
-            {
-                if (!_contextComparer.Equals(other._contextComparer))
-                {
-                    return false;
-                }
-
-                return base.Equals(other) && _contextComparer.Equals(Context, other.Context);
-            }
-
-            if (_contextComparer != null || other._contextComparer != null)
+            if (!_contextComparer.Equals(other._contextComparer))
             {
                 return false;
             }
 
-            if (Context is IEnumerable l && other.Context is IEnumerable ol)
-            {
-                // This is a common mistake; List does not implement a useful Equals for us. Work around it
-                // on behalf of our consumers...
-                return base.Equals(other) && l.Cast<object>().SequenceEqual(ol.Cast<object>());
-            }
-            
-            return base.Equals(other) && EqualityComparer<T>.Default.Equals(Context, other.Context);
+            return base.Equals(other) && _contextComparer.Equals(Context, other.Context);
         }
 
         public override bool Equals(object obj)
@@ -172,21 +155,7 @@ namespace nadena.dev.ndmf.preview
 
         public override int GetHashCode()
         {
-            if (_contextComparer != null)
-            {
-                return HashCode.Combine(
-                    base.GetHashCode(),
-                    _contextComparer.GetHashCode(),
-                    _contextComparer.GetHashCode(Context)
-                );
-            }
-
-            if (Context is IEnumerable l)
-            {
-                return l.Cast<object>().Aggregate(base.GetHashCode(), (acc, o) => HashCode.Combine(acc, o.GetHashCode()));
-            }
-            
-            return HashCode.Combine(base.GetHashCode(), EqualityComparer<T>.Default.GetHashCode(Context));
+            return HashCode.Combine(base.GetHashCode(), _contextComparer.GetHashCode(), _contextComparer.GetHashCode(Context));
         }
 
         internal override RenderGroup FilterLive()
@@ -195,6 +164,33 @@ namespace nadena.dev.ndmf.preview
 
             var live = Renderers.Where(r => r != null).ToImmutableList();
             return new RenderGroup<T>(live, DebugNames, Context, _contextComparer);
+        }
+    }
+
+    internal sealed class HeuristicContextEqualityComparer<T> : IEqualityComparer<T>
+    {
+        public static readonly HeuristicContextEqualityComparer<T> Instance = new();
+
+        public bool Equals(T x, T y)
+        {
+            if (x is IEnumerable l && y is IEnumerable ol)
+            {
+                // This is a common mistake; List does not implement a useful Equals for us. Work around it
+                // on behalf of our consumers...
+                return l.Cast<object>().SequenceEqual(ol.Cast<object>());
+            }
+            
+            return EqualityComparer<T>.Default.Equals(x, y);
+        }
+
+        public int GetHashCode(T obj)
+        {
+            if (obj is IEnumerable l)
+            {
+                return l.Cast<object>().Aggregate(0, (acc, o) => HashCode.Combine(acc, o.GetHashCode()));
+            }
+            
+            return EqualityComparer<T>.Default.GetHashCode(obj);
         }
     }
 

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using UnityEngine;
@@ -173,24 +174,75 @@ namespace nadena.dev.ndmf.preview
 
         public bool Equals(T x, T y)
         {
-            if (x is IEnumerable l && y is IEnumerable ol)
-            {
-                // This is a common mistake; List does not implement a useful Equals for us. Work around it
-                // on behalf of our consumers...
-                return l.Cast<object>().SequenceEqual(ol.Cast<object>());
-            }
-            
-            return EqualityComparer<T>.Default.Equals(x, y);
+            return HeuristicEquals(x, y);
         }
 
         public int GetHashCode(T obj)
         {
-            if (obj is IEnumerable l)
+            return HeuristicGetHashCode(obj);
+        }
+
+        private static bool HeuristicEquals(object x, object y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x == null || y == null) return false;
+
+            if (x is ITuple tuple && y is ITuple otherTuple)
             {
-                return l.Cast<object>().Aggregate(0, (acc, o) => HashCode.Combine(acc, o.GetHashCode()));
+                if (tuple.Length != otherTuple.Length) return false;
+                for (var i = 0; i < tuple.Length; i++)
+                {
+                    if (!HeuristicEquals(tuple[i], otherTuple[i])) return false;
+                }
+
+                return true;
             }
-            
-            return EqualityComparer<T>.Default.GetHashCode(obj);
+
+            if (x is IEnumerable enumerable && y is IEnumerable otherEnumerable)
+            {
+                var left = enumerable.GetEnumerator();
+                var right = otherEnumerable.GetEnumerator();
+
+                while (true)
+                {
+                    var leftHasNext = left.MoveNext();
+                    var rightHasNext = right.MoveNext();
+                    if (leftHasNext != rightHasNext) return false;
+                    if (!leftHasNext) return true;
+                    if (!HeuristicEquals(left.Current, right.Current)) return false;
+                }
+            }
+
+            return x.Equals(y);
+        }
+
+        private static int HeuristicGetHashCode(object obj)
+        {
+            if (obj == null) return 0;
+
+            if (obj is ITuple tuple)
+            {
+                var hash = 0;
+                for (var i = 0; i < tuple.Length; i++)
+                {
+                    hash = HashCode.Combine(hash, HeuristicGetHashCode(tuple[i]));
+                }
+
+                return hash;
+            }
+
+            if (obj is IEnumerable enumerable)
+            {
+                var hash = 0;
+                foreach (var entry in enumerable)
+                {
+                    hash = HashCode.Combine(hash, HeuristicGetHashCode(entry));
+                }
+
+                return hash;
+            }
+
+            return obj.GetHashCode();
         }
     }
 

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -51,9 +51,25 @@ namespace nadena.dev.ndmf.preview
             );
         }
 
+        /// <summary>
+        /// Attaches data to this render group.
+        /// This overload participates in RenderGroup equality using heuristic comparison rules.
+        /// To avoid heuristic comparison, use the explicit equality overload instead.
+        /// </summary>
         public RenderGroup WithData<T>(T data)
         {
-            return new RenderGroup<T>(Renderers, DebugNames, data);
+            return new RenderGroup<T>(Renderers, DebugNames, data, null);
+        }
+
+        /// <summary>
+        /// Attaches data to this render group and provides explicit equality for RenderGroup identity.
+        /// The supplied equality defines when two groups should be treated as the same for preview purposes,
+        /// including node reuse and cached target-group retention. Any mutable state that affects preview output should
+        /// be tracked through ComputeContext observation.
+        /// </summary>
+        public RenderGroup WithData<T>(T data, Func<T, T, bool> equals, Func<T, int> getHashCode = null)
+        {
+            return new RenderGroup<T>(Renderers, DebugNames, data, new DelegateEqualityComparer<T>(equals, getHashCode));
         }
 
         internal virtual RenderGroup Filter(HashSet<Renderer> activeRenderers)
@@ -106,20 +122,38 @@ namespace nadena.dev.ndmf.preview
     internal sealed class RenderGroup<T> : RenderGroup
     {
         public T Context { get; }
+        private readonly IEqualityComparer<T> _contextComparer;
 
         internal RenderGroup(ImmutableList<Renderer> renderers, ImmutableDictionary<Renderer, string> DebugNames,
-            T context) : base(renderers, DebugNames)
+            T context, IEqualityComparer<T> contextComparer = null) : base(renderers, DebugNames)
         {
             Context = context;
+            _contextComparer = contextComparer;
         }
         
         internal override RenderGroup Filter(HashSet<Renderer> activeRenderers)
         {
-            return new RenderGroup<T>(Renderers.RemoveAll(r => !activeRenderers.Contains(r)), DebugNames, Context);
+            var filtered = Renderers.RemoveAll(r => !activeRenderers.Contains(r));
+            return new RenderGroup<T>(filtered, DebugNames, Context, _contextComparer);
         }
         
         private bool Equals(RenderGroup<T> other)
         {
+            if (_contextComparer != null && other._contextComparer != null)
+            {
+                if (!_contextComparer.Equals(other._contextComparer))
+                {
+                    return false;
+                }
+
+                return base.Equals(other) && _contextComparer.Equals(Context, other.Context);
+            }
+
+            if (_contextComparer != null || other._contextComparer != null)
+            {
+                return false;
+            }
+
             if (Context is IEnumerable l && other.Context is IEnumerable ol)
             {
                 // This is a common mistake; List does not implement a useful Equals for us. Work around it
@@ -137,6 +171,15 @@ namespace nadena.dev.ndmf.preview
 
         public override int GetHashCode()
         {
+            if (_contextComparer != null)
+            {
+                return HashCode.Combine(
+                    base.GetHashCode(),
+                    _contextComparer.GetHashCode(),
+                    _contextComparer.GetHashCode(Context)
+                );
+            }
+
             if (Context is IEnumerable l)
             {
                 return l.Cast<object>().Aggregate(base.GetHashCode(), (acc, o) => HashCode.Combine(acc, o.GetHashCode()));
@@ -149,7 +192,54 @@ namespace nadena.dev.ndmf.preview
         {
             if (Renderers.All(r => r != null)) return this;
 
-            return new RenderGroup<T>(Renderers.Where(r => r != null).ToImmutableList(), DebugNames, Context);
+            var live = Renderers.Where(r => r != null).ToImmutableList();
+            return new RenderGroup<T>(live, DebugNames, Context, _contextComparer);
+        }
+    }
+
+    internal sealed class DelegateEqualityComparer<T> : IEqualityComparer<T>, IEquatable<DelegateEqualityComparer<T>>
+    {
+        private readonly Func<T, T, bool> _equals;
+        private readonly Func<T, int> _getHashCode;
+
+        internal DelegateEqualityComparer(Func<T, T, bool> equals, Func<T, int> getHashCode = null)
+        {
+            _equals = equals;
+            _getHashCode = getHashCode;
+        }
+
+        public bool Equals(T x, T y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+
+            return _equals(x, y);
+        }
+
+        public int GetHashCode(T obj)
+        {
+            if (obj is null) return 0;
+            return _getHashCode?.Invoke(obj) ?? 0;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is DelegateEqualityComparer<T> other && Equals(other);
+        }
+
+        public bool Equals(DelegateEqualityComparer<T> other)
+        {
+            if (ReferenceEquals(this, other)) return true;
+            if (other is null) return false;
+            if (!_equals.Equals(other._equals)) return false;
+            if (_getHashCode is null && other._getHashCode is null) return true;
+            if (_getHashCode is null || other._getHashCode is null) return false;
+            return _getHashCode.Equals(other._getHashCode);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(_equals, _getHashCode);
         }
     }
 

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -59,7 +59,7 @@ namespace nadena.dev.ndmf.preview
         /// </summary>
         public RenderGroup WithData<T>(T data)
         {
-            return new RenderGroup<T>(Renderers, DebugNames, data, null);
+            return new RenderGroup<T>(Renderers, DebugNames, data, HeuristicContextEqualityComparer<T>.Instance);
         }
 
         /// <summary>
@@ -127,10 +127,10 @@ namespace nadena.dev.ndmf.preview
         private readonly IEqualityComparer<T> _contextComparer;
 
         internal RenderGroup(ImmutableList<Renderer> renderers, ImmutableDictionary<Renderer, string> DebugNames,
-            T context, IEqualityComparer<T> contextComparer = null) : base(renderers, DebugNames)
+            T context, IEqualityComparer<T> contextComparer) : base(renderers, DebugNames)
         {
             Context = context;
-            _contextComparer = contextComparer ?? HeuristicContextEqualityComparer<T>.Instance;
+            _contextComparer = contextComparer;
         }
         
         internal override RenderGroup Filter(HashSet<Renderer> activeRenderers)
@@ -172,6 +172,8 @@ namespace nadena.dev.ndmf.preview
     {
         public static readonly HeuristicContextEqualityComparer<T> Instance = new();
 
+        private HeuristicContextEqualityComparer() { }
+        
         public bool Equals(T x, T y)
         {
             return HeuristicEquals(x, y);

--- a/Editor/PreviewSystem/ReferenceEqualityComparer.cs
+++ b/Editor/PreviewSystem/ReferenceEqualityComparer.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace nadena.dev.ndmf.preview
+{
+    internal sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T> where T : class
+    {
+        internal static readonly ReferenceEqualityComparer<T> Instance = new();
+
+        private ReferenceEqualityComparer()
+        {
+        }
+
+        public bool Equals(T x, T y)
+        {
+            return ReferenceEquals(x, y);
+        }
+
+        public int GetHashCode(T obj)
+        {
+            return RuntimeHelpers.GetHashCode(obj);
+        }
+    }
+}

--- a/Editor/PreviewSystem/ReferenceEqualityComparer.cs.meta
+++ b/Editor/PreviewSystem/ReferenceEqualityComparer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3bcaf5f90eb26ab4e9c98489d022a727
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
@@ -150,7 +150,8 @@ namespace nadena.dev.ndmf.preview
 #endif
 
             var filterList = filters.ToImmutableList();
-            _targetSet = priorPipeline?._targetSet?.Refresh(filterList, _hiddenRenderers) ?? new TargetSet(filterList, _hiddenRenderers);
+            var priorTargetSet = priorPipeline?._targetSet;
+            _targetSet = priorTargetSet?.Refresh(filterList, _hiddenRenderers) ?? new TargetSet(filterList, _hiddenRenderers, priorTargetSet);
 
             var activeStages = _targetSet.ResolveActiveStages(_ctx);
 

--- a/Editor/PreviewSystem/Rendering/TargetSet.cs
+++ b/Editor/PreviewSystem/Rendering/TargetSet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -17,8 +18,19 @@ namespace nadena.dev.ndmf.preview
         private readonly ImmutableList<IRenderFilter> _filters;
         private readonly ImmutableHashSet<Renderer> _hideRenderers;
         private readonly ComputeContext _targetSetContext = new ComputeContext("Target Set");
+        private readonly PropCache<IRenderFilter, CachedGroups> _groupsByFilterCache;
         private ImmutableList<Stage> _stages;
 
+
+        private sealed class CachedGroups
+        {
+            internal ImmutableList<RenderGroup> SortedGroups { get; }
+
+            internal CachedGroups(ImmutableList<RenderGroup> sortedGroups)
+            {
+                SortedGroups = sortedGroups;
+            }
+        }
 
         public struct Stage
         {
@@ -28,11 +40,19 @@ namespace nadena.dev.ndmf.preview
         
         public TargetSet(
             ImmutableList<IRenderFilter> filters,
-            ImmutableHashSet<Renderer> hideRenderers
+            ImmutableHashSet<Renderer> hideRenderers,
+            TargetSet prior = null
         )
         {
             _filters = filters;
             _hideRenderers = hideRenderers;
+            _groupsByFilterCache = prior?._groupsByFilterCache ?? new PropCache<IRenderFilter, CachedGroups>(
+                "TargetSet.GetTargetGroups",
+                ComputeGroupsForFilter,
+                (a, b) => a.SortedGroups.SequenceEqual(b.SortedGroups),
+                // Use reference equality comparer to avoid issues if user has overridden Equals or GetHashCode
+                ReferenceEqualityComparer<IRenderFilter>.Instance
+            );
             
             TraceBuffer.RecordTraceEvent("TargetSet.ctor", (ev) => "Get target groups");
             
@@ -45,35 +65,14 @@ namespace nadena.dev.ndmf.preview
                     if (!filter.IsEnabled(_targetSetContext)) continue;
                     
                     Profiler.BeginSample("TargetSet.GetTargetGroups[" + filter + "]");
-                    var groups = filter.GetTargetGroups(_targetSetContext);
+                    var sortedGroups = _groupsByFilterCache.Get(_targetSetContext, filter).SortedGroups;
                     Profiler.EndSample();
-                    if (groups.IsEmpty) continue;
-
-                    var unsupportedRenderer = groups.SelectMany(g => g.Renderers)
-                        .FirstOrDefault(x => x is not MeshRenderer and not SkinnedMeshRenderer);
-                    if (unsupportedRenderer != null)
-                    {
-                        Debug.LogError("[" + filter + "] Unsupported renderer " + unsupportedRenderer +
-                                       " in groups: " + string.Join(", ", groups));
-                        // Suppress this filter
-                        continue;
-                    }
-
-                    var duplicateRenderers = groups.SelectMany(g => g.Renderers)
-                        .GroupBy(r => r)
-                        .FirstOrDefault(agg => agg.Count() > 1);
-                    if (duplicateRenderers != null)
-                    {
-                        Debug.LogError("[" + filter + "] Duplicate renderer " + duplicateRenderers.Key +
-                                       " in groups: " + string.Join(", ", groups));
-                        // Suppress this filter
-                        continue;
-                    }
+                    if (sortedGroups.IsEmpty) continue;
                     
                     builder.Add(new Stage
                     {
                         Filter = filter,
-                        Groups = groups.Sort(GroupComparer)
+                        Groups = sortedGroups
                     });
                 }
                 
@@ -92,7 +91,38 @@ namespace nadena.dev.ndmf.preview
                 return this;
             }
             
-            return new TargetSet(filters, hideRenderers);
+            return new TargetSet(filters, hideRenderers, this);
+        }
+
+        private static CachedGroups ComputeGroupsForFilter(ComputeContext context, IRenderFilter filter)
+        {
+            var groups = filter.GetTargetGroups(context);
+            if (groups.IsEmpty)
+            {
+                return new CachedGroups(ImmutableList<RenderGroup>.Empty);
+            }
+
+            var unsupportedRenderer = groups.SelectMany(g => g.Renderers)
+                .FirstOrDefault(x => x is not MeshRenderer and not SkinnedMeshRenderer);
+            if (unsupportedRenderer != null)
+            {
+                Debug.LogError("[" + filter + "] Unsupported renderer " + unsupportedRenderer +
+                               " in groups: " + string.Join(", ", groups));
+                return new CachedGroups(ImmutableList<RenderGroup>.Empty);
+            }
+
+            var duplicateRenderers = groups.SelectMany(g => g.Renderers)
+                .GroupBy(r => r)
+                .FirstOrDefault(agg => agg.Count() > 1);
+            if (duplicateRenderers != null)
+            {
+                Debug.LogError("[" + filter + "] Duplicate renderer " + duplicateRenderers.Key +
+                               " in groups: " + string.Join(", ", groups));
+                return new CachedGroups(ImmutableList<RenderGroup>.Empty);
+            }
+
+            var sortedGroups = groups.Sort(GroupComparer);
+            return new CachedGroups(sortedGroups);
         }
 
         private bool RendererIsShown(ComputeContext context, Renderer renderer)

--- a/Editor/PreviewSystem/Rendering/TargetSet.cs
+++ b/Editor/PreviewSystem/Rendering/TargetSet.cs
@@ -64,7 +64,7 @@ namespace nadena.dev.ndmf.preview
                 {
                     if (!filter.IsEnabled(_targetSetContext)) continue;
                     
-                    Profiler.BeginSample("TargetSet.GetTargetGroups[" + filter + "]");
+                    Profiler.BeginSample("TargetSet.GetTargetGroupsUsingCache[" + filter + "]");
                     var sortedGroups = _groupsByFilterCache.Get(_targetSetContext, filter).SortedGroups;
                     Profiler.EndSample();
                     if (sortedGroups.IsEmpty) continue;
@@ -96,8 +96,10 @@ namespace nadena.dev.ndmf.preview
 
         private static CachedGroups ComputeGroupsForFilter(ComputeContext context, IRenderFilter filter)
         {
+            Profiler.BeginSample("TargetSet.GetTargetGroups[" + filter + "]");
             var groups = filter.GetTargetGroups(context);
-            if (groups.IsEmpty)
+            Profiler.EndSample();
+            if (groups.IsEmpty) 
             {
                 return new CachedGroups(ImmutableList<RenderGroup>.Empty);
             }


### PR DESCRIPTION
closes #774 

TargetSetにPropCacheを導入することで、プレビューにおけるパフォーマンスを改善します。
関連してRenderGroupのContextの等価比較が安定していなかったので、明示的な等価比較を引数に取るオーバーロードをRenderGroup.WithDataに追加します。また、PropCacheにoptionalなkey comparerを追加しています。

方針として問題ないか分からないので、一旦CHANGELOGは書いていません。