### PR TITLE
fix: preview node changes are not ignored when reusing nodes in entirety

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#766] Deduplicate results in `ComputeContext.GetAvatarRoots()`
+- [#777] Unnecessary preview refreshes during pipeline rebuilds.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#766] Deduplicate results in `ComputeContext.GetAvatarRoots()`
+- [#777] Unnecessary preview refreshes during pipeline rebuilds.
 
 ### Changed
 

--- a/Editor/PreviewSystem/Rendering/NodeController.cs
+++ b/Editor/PreviewSystem/Rendering/NodeController.cs
@@ -221,12 +221,7 @@ namespace nadena.dev.ndmf.preview
                 var nodeChanges = reusedNodeInEntirety ? 0 : node.WhatChanged;
 
                 var controller = new NodeController(_filter, _group, node, proxies, refCount, context, registry);
-                controller.WhatChanged = changes | nodeChanges;
-
-                foreach (var proxy in proxies)
-                {
-                    proxy.Item2.ChangeFlags |= nodeChanges;
-                }
+                controller.WhatChanged = nodeChanges;
 
                 return controller;
             }

--- a/Editor/PreviewSystem/Rendering/NodeController.cs
+++ b/Editor/PreviewSystem/Rendering/NodeController.cs
@@ -181,12 +181,14 @@ namespace nadena.dev.ndmf.preview
                                                  _group.Renderers[0].gameObject.name);
 
                 IRenderFilterNode node;
+                bool reusedNodeInEntirety;
 
                 if (changes == 0 && !IsInvalidated)
                 {
                     // Reuse the old node in its entirety
                     node = _node;
                     context = _context;
+                    reusedNodeInEntirety = true;
                 }
                 else
                 {
@@ -198,6 +200,7 @@ namespace nadena.dev.ndmf.preview
                             changes
                         );
                     }
+                    reusedNodeInEntirety = false;
                 }
 
                 RefCount refCount;
@@ -215,12 +218,14 @@ namespace nadena.dev.ndmf.preview
                     refCount = new RefCount();
                 }
 
+                var nodeChanges = reusedNodeInEntirety ? 0 : node.WhatChanged;
+
                 var controller = new NodeController(_filter, _group, node, proxies, refCount, context, registry);
-                controller.WhatChanged = changes | node.WhatChanged;
+                controller.WhatChanged = changes | nodeChanges;
 
                 foreach (var proxy in proxies)
                 {
-                    proxy.Item2.ChangeFlags |= node.WhatChanged;
+                    proxy.Item2.ChangeFlags |= nodeChanges;
                 }
 
                 return controller;


### PR DESCRIPTION
closes #555 

NDMF Preivewにおいて、ProxyPipelineの構築時に不要な下流 node の refresh / instantiate が発生する問題を修正します。Nodeが完全に再利用される際に、Nodeの変更情報が過剰に伝播され、本来完全な再利用/Refresh側に落とせた下流のNodeが再計算されていました。

04dcd030b6691d404bfc666046e9125dcb8ce8c6 では `NodeController.Refresh` で node を完全再利用した場合は、その node 自身の変更量を `0` として扱うようにしました。
77343a10e66978143c84949cb1389f535519385f では、`node.WhatChanged`をNode自身の変更のみを持つように変更し、既に`ProxyPipeline` 側で`ProxyObjectController.ChangeFlags`への反映は行っていたので、NodeController側では該当処理を削除することで、`ChangeFlags`の不要な結合・重複書き込みをなくしました。