### PR TITLE
feat: Add explicit equality overloads for `RenderGroup.WithData<T>()`.

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [#780] Add `RenderGroup.WithData<T>(T, IEqualityComparer<T>)` to explicitly define data equality.
 
 ### Fixed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ### Deprecated
+- [#780] Deprecate `RenderGroup.WithData<T>(T)` in favor of the explicit comparer overload.
 
 ## [1.12.0] - [2026-05-05]
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- [#780] Add `RenderGroup.WithData<T>(T, IEqualityComparer<T>)` to explicitly define data equality.
+- [#785] Add explicit equality overloads for `RenderGroup.WithData<T>()`.
 
 ### Fixed
 
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ### Deprecated
-- [#780] Deprecate `RenderGroup.WithData<T>(T)` in favor of the explicit comparer overload.
+- [#785] Deprecate `RenderGroup.WithData<T>(T)` because it uses heuristic equality rules.
 
 ## [1.12.0] - [2026-05-05]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [#780] Add `RenderGroup.WithData<T>(T, IEqualityComparer<T>)` to explicitly define data equality.
 
 ### Fixed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ### Deprecated
+- [#780] Deprecate `RenderGroup.WithData<T>(T)` in favor of the explicit comparer overload.
 
 ## [1.12.0] - [2026-05-05]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- [#780] Add `RenderGroup.WithData<T>(T, IEqualityComparer<T>)` to explicitly define data equality.
+- [#785] Add explicit equality overloads for `RenderGroup.WithData<T>()`.
 
 ### Fixed
 
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ### Deprecated
-- [#780] Deprecate `RenderGroup.WithData<T>(T)` in favor of the explicit comparer overload.
+- [#785] Deprecate `RenderGroup.WithData<T>(T)` because it uses heuristic equality rules.
 
 ## [1.12.0] - [2026-05-05]
 

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -51,9 +51,29 @@ namespace nadena.dev.ndmf.preview
             );
         }
 
+        /// <summary>
+        /// Returns a RenderGroup with additional data attached.
+        /// The attached data can be retrieved later using GetData.
+        /// 
+        /// This overload uses legacy heuristic equality rules; use the explicit comparer overload instead.
+        /// </summary>
+        [Obsolete("Use WithData<T>(T, IEqualityComparer<T>) instead.")]
         public RenderGroup WithData<T>(T data)
         {
-            return new RenderGroup<T>(Renderers, DebugNames, data);
+            return new RenderGroup<T>(Renderers, DebugNames, data, LegacyContextEqualityComparer<T>.Instance);
+        }
+
+        /// <summary>
+        /// Returns a RenderGroup with additional data attached.
+        /// The attached data can be retrieved later using GetData.
+        /// 
+        /// The comparer defines how the attached data participates in RenderGroup identity,
+        /// which may be used to retain target groups or reuse preview nodes.
+        /// A filter must use consistent equality semantics for the same data type.
+        /// </summary>
+        public RenderGroup WithData<T>(T data, IEqualityComparer<T> comparer)
+        {
+            return new RenderGroup<T>(Renderers, DebugNames, data, comparer);
         }
 
         internal virtual RenderGroup Filter(HashSet<Renderer> activeRenderers)
@@ -106,28 +126,29 @@ namespace nadena.dev.ndmf.preview
     internal sealed class RenderGroup<T> : RenderGroup
     {
         public T Context { get; }
+        private readonly IEqualityComparer<T> _contextComparer;
 
         internal RenderGroup(ImmutableList<Renderer> renderers, ImmutableDictionary<Renderer, string> DebugNames,
-            T context) : base(renderers, DebugNames)
+            T context, IEqualityComparer<T> contextComparer) : base(renderers, DebugNames)
         {
             Context = context;
+            _contextComparer = contextComparer;
         }
         
         internal override RenderGroup Filter(HashSet<Renderer> activeRenderers)
         {
-            return new RenderGroup<T>(Renderers.RemoveAll(r => !activeRenderers.Contains(r)), DebugNames, Context);
+            var filtered = Renderers.RemoveAll(r => !activeRenderers.Contains(r));
+            return new RenderGroup<T>(filtered, DebugNames, Context, _contextComparer);
         }
         
         private bool Equals(RenderGroup<T> other)
         {
-            if (Context is IEnumerable l && other.Context is IEnumerable ol)
-            {
-                // This is a common mistake; List does not implement a useful Equals for us. Work around it
-                // on behalf of our consumers...
-                return base.Equals(other) && l.Cast<object>().SequenceEqual(ol.Cast<object>());
-            }
-            
-            return base.Equals(other) && EqualityComparer<T>.Default.Equals(Context, other.Context);
+            // Do not compare the comparer itself.
+            // RenderGroup equality is evaluated for groups produced by the same filter
+            // across preview updates, and WithData requires consistent equality
+            // semantics for the same data type. Mixing different semantics is outside
+            // that contract.
+            return base.Equals(other) && _contextComparer.Equals(Context, other.Context);
         }
 
         public override bool Equals(object obj)
@@ -137,19 +158,44 @@ namespace nadena.dev.ndmf.preview
 
         public override int GetHashCode()
         {
-            if (Context is IEnumerable l)
-            {
-                return l.Cast<object>().Aggregate(base.GetHashCode(), (acc, o) => HashCode.Combine(acc, o.GetHashCode()));
-            }
-            
-            return HashCode.Combine(base.GetHashCode(), EqualityComparer<T>.Default.GetHashCode(Context));
+            return HashCode.Combine(base.GetHashCode(), _contextComparer.GetHashCode(Context));
         }
 
         internal override RenderGroup FilterLive()
         {
             if (Renderers.All(r => r != null)) return this;
 
-            return new RenderGroup<T>(Renderers.Where(r => r != null).ToImmutableList(), DebugNames, Context);
+            var live = Renderers.Where(r => r != null).ToImmutableList();
+            return new RenderGroup<T>(live, DebugNames, Context, _contextComparer);
+        }
+    }
+
+    internal sealed class LegacyContextEqualityComparer<T> : IEqualityComparer<T>
+    {
+        public static readonly LegacyContextEqualityComparer<T> Instance = new();
+
+        private LegacyContextEqualityComparer() { }
+        
+        public bool Equals(T x, T y)
+        {
+            if (x is IEnumerable l && y is IEnumerable ol)
+            {
+                // This is a common mistake; List does not implement a useful Equals for us. Work around it
+                // on behalf of our consumers...
+                return l.Cast<object>().SequenceEqual(ol.Cast<object>());
+            }
+
+            return EqualityComparer<T>.Default.Equals(x, y);
+        }
+
+        public int GetHashCode(T obj)
+        {
+            if (obj is IEnumerable l)
+            {
+                return l.Cast<object>().Aggregate(0, (acc, o) => HashCode.Combine(acc, o.GetHashCode()));
+            }
+            
+            return EqualityComparer<T>.Default.GetHashCode(obj); 
         }
     }
 

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -148,7 +148,15 @@ namespace nadena.dev.ndmf.preview
             // across preview updates, and WithData requires consistent equality
             // semantics for the same data type. Mixing different semantics is outside
             // that contract.
-            return base.Equals(other) && _contextComparer.Equals(Context, other.Context);
+            return base.Equals(other) && ContextEquals(Context, other.Context);
+        }
+
+        private bool ContextEquals(T x, T y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+
+            return _contextComparer.Equals(x, y);
         }
 
         public override bool Equals(object obj)
@@ -158,7 +166,10 @@ namespace nadena.dev.ndmf.preview
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(base.GetHashCode(), _contextComparer.GetHashCode(Context));
+            return HashCode.Combine(
+                base.GetHashCode(),
+                Context is null ? 0 : _contextComparer.GetHashCode(Context)
+            );
         }
 
         internal override RenderGroup FilterLive()

--- a/Editor/PreviewSystem/IRenderFilter.cs
+++ b/Editor/PreviewSystem/IRenderFilter.cs
@@ -55,12 +55,25 @@ namespace nadena.dev.ndmf.preview
         /// Returns a RenderGroup with additional data attached.
         /// The attached data can be retrieved later using GetData.
         /// 
-        /// This overload uses legacy heuristic equality rules; use the explicit comparer overload instead.
+        /// This overload uses legacy heuristic equality rules; use an explicit equality overload instead.
         /// </summary>
-        [Obsolete("Use WithData<T>(T, IEqualityComparer<T>) instead.")]
+        [Obsolete("Use an explicit equality overload instead.")]
         public RenderGroup WithData<T>(T data)
         {
             return new RenderGroup<T>(Renderers, DebugNames, data, LegacyContextEqualityComparer<T>.Instance);
+        }
+
+        /// <summary>
+        /// Returns a RenderGroup with additional data attached.
+        /// The attached data can be retrieved later using GetData.
+        /// 
+        /// The equality function defines how the attached data participates in RenderGroup identity,
+        /// which may be used to retain target groups or reuse preview nodes.
+        /// A filter must use consistent equality semantics for the same data type.
+        /// </summary>
+        public RenderGroup WithData<T>(T data, Func<T, T, bool> equals)
+        {
+            return new RenderGroup<T>(Renderers, DebugNames, data, new DelegateEqualityComparer<T>(equals));
         }
 
         /// <summary>
@@ -178,6 +191,26 @@ namespace nadena.dev.ndmf.preview
 
             var live = Renderers.Where(r => r != null).ToImmutableList();
             return new RenderGroup<T>(live, DebugNames, Context, _contextComparer);
+        }
+    }
+
+    internal sealed class DelegateEqualityComparer<T> : IEqualityComparer<T>
+    {
+        private readonly Func<T, T, bool> _equals;
+
+        public DelegateEqualityComparer(Func<T, T, bool> equals)
+        {
+            _equals = equals;
+        }
+
+        public bool Equals(T x, T y)
+        {
+            return _equals(x, y);
+        }
+
+        public int GetHashCode(T obj)
+        {
+            return 0;
         }
     }
 


### PR DESCRIPTION
closes #784 

`RenderGroup.WithData`に対し、明示的な等価比較としてデリゲートもしくは`IEqualityComparer`を要求するAPIを追加します
また、明示的な等価比較を要求していない旧APIを非推奨に変更しています