### PR TITLE
fix: `IRenderFilter` instance could be registered multiple times.

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#786] Fixed an issue where an `IRenderFilter` instance could be registered multiple times.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#786] Fixed an issue where an `IRenderFilter` instance could be registered multiple times.
 
 ### Changed
 

--- a/Editor/API/Fluent/Sequence/Sequence.cs
+++ b/Editor/API/Fluent/Sequence/Sequence.cs
@@ -59,6 +59,9 @@ namespace nadena.dev.ndmf.fluent
             _seq = seq;
         }
 
+        /// <summary>
+        /// Registers preview filters for this pass. Each filter instance may be registered only once.
+        /// </summary>
         public DeclaringPass PreviewingWith(params IRenderFilter[] filters)
         {
             foreach (var filter in filters)

--- a/Editor/PreviewSystem/PreviewSession.cs
+++ b/Editor/PreviewSystem/PreviewSession.cs
@@ -73,6 +73,7 @@ namespace nadena.dev.ndmf.preview
         private readonly Sequencer _sequence = new Sequencer();
 
         private Dictionary<SequencePoint, IRenderFilter> _filters = new();
+        private HashSet<IRenderFilter> _registeredFilters = new(ReferenceEqualityComparer<IRenderFilter>.Instance);
 
         private ProxySession _proxySession;
 
@@ -110,6 +111,7 @@ namespace nadena.dev.ndmf.preview
             _proxySession = new ProxySession(ImmutableList<IRenderFilter>.Empty);
             _sequence = source._sequence.Clone();
             _filters = source._filters.ToDictionary(kv => kv.Key, kv => kv.Value);
+            _registeredFilters = source._registeredFilters.ToHashSet(ReferenceEqualityComparer<IRenderFilter>.Instance);
             _name = name;
             ForceRebuild();
         }
@@ -134,8 +136,20 @@ namespace nadena.dev.ndmf.preview
             RebuildSequence();
         }
 
+        /// <summary>
+        /// A render filter instance must be registered at only one sequence point.
+        /// </summary>
         public IDisposable AddMutator(SequencePoint sequencePoint, IRenderFilter filter)
         {
+            if (!_registeredFilters.Add(filter))
+            {
+                Debug.LogError(
+                    "The same IRenderFilter instance is already registered. Create a new filter instance for each SequencePoint. " +
+                    "Ignoring the duplicate registration."
+                );
+                return new EmptyDisposable();
+            }
+
             _sequence.AddPoint(sequencePoint);
 
             _filters.Add(sequencePoint, filter);
@@ -158,8 +172,11 @@ namespace nadena.dev.ndmf.preview
 
             public void Dispose()
             {
-                _session._filters.Remove(_point);
-                _session.RebuildSequence();
+                if (_session._filters.Remove(_point, out var filter))
+                {
+                    _session._registeredFilters.Remove(filter);
+                    _session.RebuildSequence();
+                }
             }
         }
 


### PR DESCRIPTION
closes #781 

同一の`IRenderFilter`のインスタンスが登録された際に警告を出したうえで無視するように変更しています。
一応GitHub上である程度検索した範囲ではこの変更で壊れるプラグインもなさそうです