### PR TITLE
fix: IRenderFilterNode.Refresh() is not called when MeshFilter's mesh is replaced

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#794] `IRenderFilterNode.Refresh()` is not called when MeshFilter's mesh is replaced.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#794] `IRenderFilterNode.Refresh()` is not called when MeshFilter's mesh is replaced.
 
 ### Changed
 

--- a/Editor/PreviewSystem/Rendering/ProxyObjectController.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyObjectController.cs
@@ -104,11 +104,12 @@ namespace nadena.dev.ndmf.preview
             }
             else if (r is MeshRenderer mr)
             {
-                var meshRenderer = _monitorMesh.GetComponent<MeshFilter>(r.gameObject);
-                if (meshRenderer != null)
+                var meshFilter = _monitorMesh.GetComponent<MeshFilter>(r.gameObject);
+                if (meshFilter != null)
                 {
-                    _monitorMesh.Observe(meshRenderer.sharedMesh);
-                    _initialSharedMesh = meshRenderer.sharedMesh;
+                    _monitorMesh.Observe(meshFilter);
+                    _monitorMesh.Observe(meshFilter.sharedMesh);
+                    _initialSharedMesh = meshFilter.sharedMesh;
                 }
             }
 


### PR DESCRIPTION
Fixes: #793