### PR TITLE
feat: Compatibility with unity 6.4.

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
-- [#795] Fix issues with preview system on Unity 6000.4
+- [#795] Fix compatibility issues with Unity 6000.x
 
 ### Changed
 

--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#795] Fix issues with preview system on Unity 6000.4
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
-- [#795] Fix issues with preview system on Unity 6000.4
+- [#795] Fix compatibility issues with Unity 6000.x
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#795] Fix issues with preview system on Unity 6000.4
 
 ### Changed
 

--- a/Editor/ErrorReporting/UI/ErrorIcon.cs
+++ b/Editor/ErrorReporting/UI/ErrorIcon.cs
@@ -13,7 +13,10 @@ namespace nadena.dev.ndmf.ui
     /// <summary>
     /// Displays a severity icon for a particular ErrorLevel.
     /// </summary>
-    public sealed class ErrorIcon : VisualElement
+#if UNITY_6000_4_OR_NEWER
+    [UxmlElement]
+#endif
+    public sealed partial class ErrorIcon : VisualElement
     {
         private ErrorSeverity _severity;
 
@@ -54,7 +57,24 @@ namespace nadena.dev.ndmf.ui
 
             _image.image = tex;
         }
+#if UNITY_6000_4_OR_NEWER
+        [UxmlAttribute]
+        public string category
+        {
+            get => _severity.ToString();
+            set
+            {
+                if (value == null || !Enum.TryParse<ErrorSeverity>(value, out var categoryVal))
+                {
+                    categoryVal = ErrorSeverity.Error;
+                }
 
+                _severity = categoryVal;
+            }
+        }
+#endif
+
+#if !UNITY_6000_4_OR_NEWER
         public new class UxmlFactory : UxmlFactory<ErrorIcon, UxmlTraits>
         {
         }
@@ -84,5 +104,6 @@ namespace nadena.dev.ndmf.ui
                 elem.Severity = categoryVal;
             }
         }
+#endif
     }
 }

--- a/Editor/ErrorReporting/UI/ErrorIcon.cs
+++ b/Editor/ErrorReporting/UI/ErrorIcon.cs
@@ -13,7 +13,7 @@ namespace nadena.dev.ndmf.ui
     /// <summary>
     /// Displays a severity icon for a particular ErrorLevel.
     /// </summary>
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
     public sealed partial class ErrorIcon : VisualElement
@@ -74,7 +74,7 @@ namespace nadena.dev.ndmf.ui
         }
 #endif
 
-#if !UNITY_6000_4_OR_NEWER
+#if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<ErrorIcon, UxmlTraits>
         {
         }

--- a/Editor/Harmony/HandleUtilityPatches.cs
+++ b/Editor/Harmony/HandleUtilityPatches.cs
@@ -70,17 +70,21 @@ namespace nadena.dev.ndmf.preview
                 return array;
             }
         }
-        
+
         internal static void Patch_FilterInstanceIDs(Harmony h)
         {
             var t_HandleUtility = AccessTools.TypeByName("UnityEditor.HandleUtility");
-            var m_orig = AccessTools.Method(t_HandleUtility, "FilterInstanceIDs");
-
+            var m_orig = AccessTools.Method(t_HandleUtility,
+#if UNITY_6000_4_OR_NEWER
+            "FilterEntityIds"
+#else
+            "FilterInstanceIDs"
+#endif
+            );
             var m_prefix = AccessTools.Method(typeof(HandleUtilityPatches), "Prefix_FilterInstanceIDs");
             var m_postfix = AccessTools.Method(typeof(HandleUtilityPatches), "Postfix_FilterInstanceIDs");
 
             h.Patch(original: m_orig, prefix: new HarmonyMethod(m_prefix), postfix: new HarmonyMethod(m_postfix));
-
             var m_internal_getclosestpickingid = AccessTools.Method(t_HandleUtility, "Internal_GetClosestPickingID");
             var m_prefix_internal_getclosestpickingid = AccessTools.Method(typeof(HandleUtilityPatches),
                 nameof(Prefix_Internal_GetClosestPickingID));
@@ -161,18 +165,34 @@ namespace nadena.dev.ndmf.preview
             bool drawGizmos,
             ref int materialIndex,
             ref bool isEntity,
+#if UNITY_6000_4_OR_NEWER
+            ref ulong __result
+#else
             ref uint __result
+#endif
         )
         {
             var sess = PreviewSession.Current;
             if (sess == null) return;
 
-            var go = EditorUtility.InstanceIDToObject((int)__result) as GameObject;
+            var go =
+#if UNITY_6000_4_OR_NEWER
+            EditorUtility.EntityIdToObject(EntityId.FromULong(__result))
+#else
+            EditorUtility.InstanceIDToObject((int)__result)
+#endif
+             as GameObject;
             if (go == null) return;
 
             if (sess.ProxyToOriginalObject.TryGetValue(go, out var original) && original != null)
             {
-                __result = (uint)original.GetInstanceID();
+                __result =
+#if UNITY_6000_4_OR_NEWER
+               EntityId.ToULong(original.GetEntityId())
+#else
+                (uint)original.GetInstanceID()
+#endif
+                ;
             }
         }
 
@@ -199,6 +219,21 @@ namespace nadena.dev.ndmf.preview
             }
         }
 
+#if UNITY_6000_4_OR_NEWER
+        [UsedImplicitly]
+        private static bool Prefix_FilterInstanceIDs(
+            ref IEnumerable<GameObject> gameObjects,
+            out EntityId[] parentEntityIds,
+            out EntityId[] childEntityIds,
+            out HashSet<EntityId> childEntityIdsHashSet
+        )
+        {
+            gameObjects = RemapObjects(gameObjects);
+            parentEntityIds = childEntityIds = null;
+            childEntityIdsHashSet = null;
+            return true;
+        }
+#else
         [UsedImplicitly]
         private static bool Prefix_FilterInstanceIDs(
             ref IEnumerable<GameObject> gameObjects,
@@ -210,7 +245,22 @@ namespace nadena.dev.ndmf.preview
             parentInstanceIDs = childInstanceIDs = null;
             return true;
         }
+#endif
 
+#if UNITY_6000_4_OR_NEWER
+
+        [UsedImplicitly]
+        private static void Postfix_FilterInstanceIDs(
+            ref IEnumerable<GameObject> gameObjects,
+            ref EntityId[] parentEntityIds,
+            ref EntityId[] childEntityIds,
+            ref HashSet<EntityId> childEntityIdsHashSet
+        )
+        {
+            ref var parentInstanceIDs = ref parentEntityIds;
+            ref var childInstanceIDs = ref childEntityIds;
+            childEntityIdsHashSet = null;
+#else
         [UsedImplicitly]
         private static void Postfix_FilterInstanceIDs(
             ref IEnumerable<GameObject> gameObjects,
@@ -218,10 +268,12 @@ namespace nadena.dev.ndmf.preview
             ref int[] childInstanceIDs
         )
         {
+            HashSet<int> childEntityIdsHashSet = null;
+#endif
             var sess = PreviewSession.Current;
             if (sess == null) return;
 
-            HashSet<int> newChildInstanceIDs = null;
+
 
             foreach (var parent in gameObjects)
             {
@@ -229,15 +281,21 @@ namespace nadena.dev.ndmf.preview
                 {
                     if (sess.OriginalToProxyRenderer.TryGetValue(renderer, out var proxy) && proxy != null)
                     {
-                        if (newChildInstanceIDs == null) newChildInstanceIDs = new HashSet<int>(childInstanceIDs);
-                        newChildInstanceIDs.Add(proxy.GetInstanceID());
+                        if (childEntityIdsHashSet == null) childEntityIdsHashSet = new(childInstanceIDs);
+                        childEntityIdsHashSet.Add(
+#if UNITY_6000_4_OR_NEWER
+                            proxy.GetEntityId()
+#else
+                            proxy.GetInstanceID()
+#endif
+                        );
                     }
                 }
             }
 
-            if (newChildInstanceIDs != null)
+            if (childEntityIdsHashSet != null)
             {
-                childInstanceIDs = newChildInstanceIDs.ToArray();
+                childInstanceIDs = childEntityIdsHashSet.ToArray();
             }
         }
 

--- a/Editor/UI/LanguageSwitcher.cs
+++ b/Editor/UI/LanguageSwitcher.cs
@@ -8,8 +8,12 @@ namespace nadena.dev.ndmf.ui
     /// <summary>
     /// VisualElement to display a language selector.
     /// </summary>
-    public sealed class LanguageSwitcher : VisualElement
+#if UNITY_6000_4_OR_NEWER
+    [UxmlElement]
+#endif
+    public sealed partial class LanguageSwitcher : VisualElement
     {
+#if !UNITY_6000_4_OR_NEWER
         public new class UxmlFactory : UxmlFactory<LanguageSwitcher, UxmlTraits>
         {
         }
@@ -17,6 +21,7 @@ namespace nadena.dev.ndmf.ui
         public new class UxmlTraits : VisualElement.UxmlTraits
         {
         }
+#endif
 
         public LanguageSwitcher()
         {

--- a/Editor/UI/LanguageSwitcher.cs
+++ b/Editor/UI/LanguageSwitcher.cs
@@ -8,12 +8,12 @@ namespace nadena.dev.ndmf.ui
     /// <summary>
     /// VisualElement to display a language selector.
     /// </summary>
-#if UNITY_6000_4_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
     [UxmlElement]
 #endif
     public sealed partial class LanguageSwitcher : VisualElement
     {
-#if !UNITY_6000_4_OR_NEWER
+#if !UNITY_6000_0_OR_NEWER
         public new class UxmlFactory : UxmlFactory<LanguageSwitcher, UxmlTraits>
         {
         }


### PR DESCRIPTION
[AAO の方の PR](https://github.com/anatawa12/AvatarOptimizer/pull/1711) の都合もあってこっちも PR にしました。

主な内容は Unity 6.4 環境にて、 Uxml 周辺の修正と NDMF Preview のために行われている Harmony パッチの修正になります。

Uxml は SourceGenerator 方式に変わっているようなのでそれに合わせて #if で区切りながら対応し、Harmony パッチの部分は、 InstanceID から EntityId に名前が変わっていたり少し引数が違う部分を結構強引に #if で区切って解決しています。この部分に関しては実装を結構複製して #if の複雑度を下げてもいいかもしれません。