### PR TITLE
fix: incorrect original object recorded in ObjectRegistry when AnimatorOverrideControllers are in use

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#801] Fixed issue where AnimatorOverrideControllers mapping from proxy animations could be ignored when other tools
+  directly manipulate animator controllers.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#801] Fixed issue where AnimatorOverrideControllers mapping from proxy animations could be ignored when other tools
+  directly manipulate animator controllers.
 
 ### Changed
 

--- a/Editor/API/AnimatorServices/CloneContext.cs
+++ b/Editor/API/AnimatorServices/CloneContext.cs
@@ -157,7 +157,7 @@ namespace nadena.dev.ndmf.animator
                 value = clone(this, key);
                 _clones[key] = value;
 
-                if (value is object node && key is Object unityObj)
+                if (value is VirtualNode node && node.OriginalObjectExposed is { } unityObj)
                 {
                     NodeToReference[node] = ObjectRegistry.GetReference(unityObj);
                 }

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualNode.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualNode.cs
@@ -48,6 +48,10 @@ namespace nadena.dev.ndmf.animator
         /// </summary>
         protected Object? OriginalObject { get; set; }
 
+        // this workaround is needed to allow other internal classes to access OriginalObject without adding it to the
+        // public API
+        internal Object? OriginalObjectExposed => OriginalObject;
+
         // The name of the associated unity object. 
         public abstract string Name { get; set; }
 

--- a/UnitTests~/AnimationServices/AnimatorOverrideControllerTest.cs
+++ b/UnitTests~/AnimationServices/AnimatorOverrideControllerTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using nadena.dev.ndmf;
 using nadena.dev.ndmf.animator;
 using NUnit.Framework;
 using UnityEditor.Animations;
@@ -39,6 +40,52 @@ namespace UnitTests.AnimationServices
             
             Assert.AreEqual("c3", virtualS1.State.Motion.Name);
             Assert.AreEqual("c2", virtualS2.State.Motion.Name);
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/bdunderscore/ndmf/issues/800
+        /// When an AOC substitutes c1 with c2, the ObjectRegistry must record that the committed clone
+        /// replaces c2 (the override clip), not c1 (the original clip in the base controller).
+        /// </summary>
+        [Test]
+        public void ObjectRegistry_MapsOverrideClipNotOriginalClip()
+        {
+            var objectRegistry = new ObjectRegistry(null);
+            var reg = (IObjectRegistry)objectRegistry;
+
+            var cloneContext = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+
+            var originalController = new AnimatorController();
+            var originalStateMachine = new AnimatorStateMachine();
+            originalController.layers = new[] {new AnimatorControllerLayer {stateMachine = originalStateMachine}};
+
+            var c1 = new AnimationClip {name = "c1"};
+            var c2 = new AnimationClip {name = "c2"};
+
+            var s1 = new AnimatorState {name = "s1", motion = c1};
+            originalStateMachine.states = new[] {new ChildAnimatorState {state = s1}};
+            originalStateMachine.defaultState = s1;
+
+            var overrideController = new AnimatorOverrideController();
+            overrideController.runtimeAnimatorController = originalController;
+            overrideController[c1] = c2;
+
+            VirtualAnimatorController virtualController;
+            AnimatorController committed;
+
+            using (new ObjectRegistryScope(objectRegistry))
+            {
+                virtualController = cloneContext.Clone(overrideController);
+
+                var commitContext = new CommitContext();
+                commitContext.NodeToReference = cloneContext.NodeToReference;
+                committed = commitContext.CommitObject(virtualController);
+            }
+
+            var committedMotion = (AnimationClip) committed.layers[0].stateMachine.defaultState.motion;
+
+            // The committed clip must resolve to c2's reference, not c1's.
+            Assert.AreEqual(reg.GetReference(c2), reg.GetReference(committedMotion));
         }
 
         [Test]

--- a/UnitTests~/AnimationServices/ReactivationTest.cs
+++ b/UnitTests~/AnimationServices/ReactivationTest.cs
@@ -1,9 +1,12 @@
 ﻿#if NDMF_VRCSDK3_AVATARS
 
+using System.IO;
 using System.Linq;
+using nadena.dev.ndmf;
 using nadena.dev.ndmf.animator;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
 using VRC.SDK3.Avatars.Components;
@@ -125,6 +128,97 @@ namespace UnitTests.AnimationServices
             Assert.AreNotSame(stage1, stage2);
         }
         
+        /// <summary>
+        /// Regression test for https://github.com/bdunderscore/ndmf/issues/761 and
+        /// https://github.com/anatawa12/AvatarOptimizer/issues/1664.
+        /// When an AnimatorOverrideController replaces a VRChat proxy animation, the override must not revert
+        /// to the proxy after VirtualControllerContext is deactivated, externally modified, and reactivated.
+        /// The root cause was that the ObjectRegistry incorrectly recorded the original (proxy) clip rather than
+        /// the override clip, causing re-cloning on the second activation to treat the committed clip as a proxy
+        /// marker and substitute it back.
+        /// </summary>
+        [Test]
+        public void WhenAOCReplacesProxyAnimation_OverrideIsPreservedAfterReactivation()
+        {
+            // Load any VRChat proxy animation (must be recognized as a special motion)
+            var proxyClipPath = AssetDatabase
+                .FindAssets("t:AnimationClip", new[] { "Packages/com.vrchat.avatars" })
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .FirstOrDefault(p => Path.GetFileNameWithoutExtension(p).StartsWith("proxy_"));
+
+            if (proxyClipPath == null) Assert.Ignore("No VRChat proxy animation found; is the VRChat SDK installed?");
+
+            var proxyClip = AssetDatabase.LoadAssetAtPath<AnimationClip>(proxyClipPath);
+            Assert.IsNotNull(proxyClip);
+
+            var root = CreateRoot("root");
+            var vrcDesc = root.GetComponent<VRCAvatarDescriptor>();
+
+            // Build a single-layer base controller whose default state uses the proxy animation
+            var baseController = new AnimatorController();
+            var sm = new AnimatorStateMachine();
+            var state = new AnimatorState { motion = proxyClip };
+            sm.states = new[] { new ChildAnimatorState { state = state } };
+            sm.defaultState = state;
+            baseController.layers = new[] { new AnimatorControllerLayer { stateMachine = sm } };
+
+            // AOC replaces the proxy with a new empty clip
+            var overrideClip = TrackObject(new AnimationClip { name = "override" });
+            var aoc = new AnimatorOverrideController();
+            aoc.runtimeAnimatorController = baseController;
+            aoc[proxyClip] = overrideClip;
+
+            // Install the AOC as the FX layer
+            vrcDesc.customizeAnimationLayers = true;
+            var vrcLayers = vrcDesc.baseAnimationLayers;
+            for (int i = 0; i < vrcLayers.Length; i++)
+            {
+                if (vrcLayers[i].type == VRCAvatarDescriptor.AnimLayerType.FX)
+                {
+                    vrcLayers[i].animatorController = aoc;
+                    vrcLayers[i].isDefault = false;
+                    break;
+                }
+            }
+            vrcDesc.baseAnimationLayers = vrcLayers;
+
+            var context = CreateContext(root);
+            var objectRegistry = new ObjectRegistry(root.transform);
+
+            using (new ObjectRegistryScope(objectRegistry))
+            {
+                // Step 1: Activate
+                context.ActivateExtensionContext<VirtualControllerContext>();
+                // Step 2: Deactivate — FX layer is now a plain AnimatorController with the AOC applied
+                context.DeactivateExtensionContext<VirtualControllerContext>();
+
+                // Step 3: Simulate an external plugin modifying the committed controller without going
+                // through the Virtual Animator API (e.g. AvatarOptimizer's Trace and Optimize).
+                // Adding a layer mutates the controller, which triggers OnAnimatorControllerDirty and
+                // clears LastCommit, forcing VirtualControllerContext to perform a fresh clone on the
+                // next activation rather than reusing the cached virtual controller.
+                var fxAfterFirst = vrcDesc.baseAnimationLayers
+                    .First(l => l.type == VRCAvatarDescriptor.AnimLayerType.FX);
+                var committedController = (AnimatorController)fxAfterFirst.animatorController;
+                committedController.layers = committedController.layers
+                    .Append(new AnimatorControllerLayer { name = "dummy", stateMachine = new AnimatorStateMachine() })
+                    .ToArray();
+
+                // Step 4: Activate again — must re-clone from the committed controller
+                context.ActivateExtensionContext<VirtualControllerContext>();
+                // Step 5: Deactivate
+                context.DeactivateExtensionContext<VirtualControllerContext>();
+            }
+
+            // Step 6: Assert the motion has NOT reverted to the original proxy animation
+            var fxFinal = vrcDesc.baseAnimationLayers
+                .First(l => l.type == VRCAvatarDescriptor.AnimLayerType.FX);
+            var finalController = (AnimatorController)fxFinal.animatorController;
+            var finalMotion = finalController.layers[0].stateMachine.defaultState.motion;
+
+            Assert.AreNotSame(proxyClip, finalMotion,
+                "Motion reverted to the original proxy animation after context reactivation");
+        }
     }
 }
 


### PR DESCRIPTION
Closes: #800, #761
