### PR TITLE
feat: reinitialize VRCConstraints on play

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#821] Changes to VRCConstraints may not affect behavior of VRCConstraints
 - [#822] Fix an occasional NullReferenceError in ProxyPipeline
 - [#823] Performance improvements for NDMF previews
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#821] Changes to VRCConstraints may not affect behavior of VRCConstraints
 - [#822] Fix an occasional NullReferenceError in ProxyPipeline
 - [#823] Performance improvements for NDMF previews
 

--- a/Editor/VRChat/ForceReinitVRCConstraintsHook.cs
+++ b/Editor/VRChat/ForceReinitVRCConstraintsHook.cs
@@ -1,0 +1,44 @@
+#if NDMF_VRCSDK3_AVATARS_VRC_CONSTRAINTS
+#region
+
+using System;
+using System.Reflection;
+using UnityEngine;
+using VRC.Dynamics;
+using VRC.SDKBase.Editor.BuildPipeline;
+
+#endregion
+
+namespace nadena.dev.ndmf.VRChat
+{
+    internal class ForceReinitVRCConstraintsHook : IVRCSDKPreprocessAvatarCallback
+    {
+        public int callbackOrder => int.MaxValue;
+
+        public bool OnPreprocessAvatar(GameObject avatarGameObject)
+        {
+            if (Application.isPlaying)
+            {
+                var awake = typeof(VRCConstraintBase).GetMethod("Awake", BindingFlags.NonPublic | BindingFlags.Instance, null, Type.EmptyTypes, null);
+                var isRuntimeTargetTransformAssigned = typeof(VRCConstraintBase).GetField("_isRuntimeTargetTransformAssigned", BindingFlags.NonPublic | BindingFlags.Instance);
+                if (awake != null && isRuntimeTargetTransformAssigned != null)
+                {
+                    foreach (var collider in avatarGameObject.GetComponentsInChildren<VRCConstraintBase>(true))
+                    {
+                        isRuntimeTargetTransformAssigned.SetValue(collider, false);
+                        awake.Invoke(collider, null);
+                    }
+                }
+                else
+                {
+                    Debug.LogError("VRCConstraintBase.Awake() or _isRuntimeTargetTransformAssigned couldn't find. skipping re-initializing VRCConstraint");
+                }
+                VRCDynamicsScheduler.UpdateConstraints(true);
+            }
+
+            return true;
+        }
+    }
+}
+
+#endif

--- a/Editor/VRChat/nadena.dev.ndmf.vrchat.asmdef
+++ b/Editor/VRChat/nadena.dev.ndmf.vrchat.asmdef
@@ -32,6 +32,11 @@
             "name": "com.vrchat.avatars",
             "expression": "3.10.3",
             "define": "NDMF_VRCSDK3_AVATARS_3_10_3_OR_NEWER"
+        },
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "3.7.0",
+            "define": "NDMF_VRCSDK3_AVATARS_VRC_CONSTRAINTS"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
VRCConstraintsの `_isRuntimeTargetTransformAssigned` および `_runtimeTargetTransformAssigned` 関連フィールドを NDMF ビルド完了時に初期化するようにします。

これがないと VRCConstraints の中身を変更するプラグインで正しく実行時に適用される中身が置き換わらない問題が発生します

<img width="1210" height="840" alt="image" src="https://github.com/user-attachments/assets/88b22542-4d9b-41dd-af7f-d99dfe213717" />