### PR TITLE
fix: compile error with VRCSDK 3.9.x or earlier

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#825] Compile error with VRChat SDK 3.9.0 or earlier
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#825] Compile error with VRChat SDK 3.9.0 or earlier
 
 ### Changed
 

--- a/Editor/VRChat/ForceReinitVRCConstraintsHook.cs
+++ b/Editor/VRChat/ForceReinitVRCConstraintsHook.cs
@@ -33,7 +33,13 @@ namespace nadena.dev.ndmf.VRChat
                 {
                     Debug.LogError("VRCConstraintBase.Awake() or _isRuntimeTargetTransformAssigned couldn't find. skipping re-initializing VRCConstraint");
                 }
+#if NDMF_VRCSDK3_AVATARS_VRC_DYNAMICS_FOR_WORLDS
                 VRCDynamicsScheduler.UpdateConstraints(true);
+#elseif NDMF_VRCSDK3_AVATARS_PHYSBONE_CONTACT_INTEGRATION
+                VRCAvatarDynamicsScheduler.UpdateConstraints(true);
+#else
+                VRCConstraintManager.UpdateConstraints();
+#endif
             }
 
             return true;

--- a/Editor/VRChat/ForceReinitVRCConstraintsHook.cs
+++ b/Editor/VRChat/ForceReinitVRCConstraintsHook.cs
@@ -35,7 +35,7 @@ namespace nadena.dev.ndmf.VRChat
                 }
 #if NDMF_VRCSDK3_AVATARS_VRC_DYNAMICS_FOR_WORLDS
                 VRCDynamicsScheduler.UpdateConstraints(true);
-#elseif NDMF_VRCSDK3_AVATARS_PHYSBONE_CONTACT_INTEGRATION
+#elif NDMF_VRCSDK3_AVATARS_PHYSBONE_CONTACT_INTEGRATION
                 VRCAvatarDynamicsScheduler.UpdateConstraints(true);
 #else
                 VRCConstraintManager.UpdateConstraints();

--- a/Editor/VRChat/nadena.dev.ndmf.vrchat.asmdef
+++ b/Editor/VRChat/nadena.dev.ndmf.vrchat.asmdef
@@ -37,6 +37,16 @@
             "name": "com.vrchat.avatars",
             "expression": "3.7.0",
             "define": "NDMF_VRCSDK3_AVATARS_VRC_CONSTRAINTS"
+        },
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "3.10.0",
+            "define": "NDMF_VRCSDK3_AVATARS_VRC_DYNAMICS_FOR_WORLDS"
+        },
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "3.7.3",
+            "define": "NDMF_VRCSDK3_AVATARS_PHYSBONE_CONTACT_INTEGRATION"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
Fixes https://github.com/bdunderscore/ndmf/pull/821#discussion_r3700832128

- VRCSDK 3.7.0 introduced VRCConstraints, and `VRCConstraintManager` were added.
- VRCSDK 3.7.3 added integration with VRChysBone to fix jittering. This introduces `VRCAvatarDynamicsScheduler`
  https://creators.vrchat.com/releases/release-3-7-3#fixes--changes
  > Improved [Physbone](https://creators.vrchat.com/common-components/physbones) and [Contact](https://creators.vrchat.com/common-components/contacts) behavior when used beneath [VRChat Constraints](https://creators.vrchat.com/common-components/constraints) to reduce jittering.
- VRCSDK 3.10.0 introduced VRCConstraints for VRChat Worlds. VRChat Dynamics are no longer for Avatars so `VRCAvatarDynamicsScheduler` was renamed to `VRCDynamicsScheduler`

it might be `VRCConstraintManager.UpdateConstraints();` is enough but I think it's hard to to test so I'll keep resetting as much as possible,