### PR TITLE
fix: resolve AnimatorOverrideController mappings after cloning instead of during it

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#829] AnimatorOverrideControllers with swapped or cross-referencing clip mappings now produce correct build output
 
 ### Changed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ### Deprecated
+- `CloneContext.MapClipOnClone()` no longer performs any mapping and is marked obsolete; AnimatorOverrideController mappings are now applied automatically after cloning completes.
 
 ## [1.14.5] - [2026-08-20]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#829] AnimatorOverrideControllers with swapped or cross-referencing clip mappings now produce correct build output
 
 ### Changed
 

--- a/Editor/API/AnimatorServices/CloneContext.cs
+++ b/Editor/API/AnimatorServices/CloneContext.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using UnityEditor.Animations;
@@ -29,17 +28,11 @@ namespace nadena.dev.ndmf.animator
 
         private struct DynamicScopeState
         {
-            public ImmutableList<AnimatorOverrideController> OverrideControllers;
             public object? InnateAnimatorKey;
             public Func<int, int>? PhysicalToVirtualLayerMapper;
         }
 
-        private DynamicScopeState _curDynScope = new()
-        {
-            OverrideControllers = ImmutableList<AnimatorOverrideController>.Empty
-        };
-
-        private ImmutableList<AnimatorOverrideController> OverrideControllers => _curDynScope.OverrideControllers;
+        private DynamicScopeState _curDynScope = new();
 
         /// <summary>
         ///     When cloning an innate animator, this property will be set to the key of the animator.
@@ -85,15 +78,6 @@ namespace nadena.dev.ndmf.animator
             }
         }
 
-        internal IDisposable PushOverrideController(AnimatorOverrideController controller)
-        {
-            var scope = new DynamicScope(this);
-
-            _curDynScope.OverrideControllers = _curDynScope.OverrideControllers.Add(controller);
-
-            return scope;
-        }
-
         internal IDisposable PushActiveInnateKey(object? key)
         {
             var scope = new DynamicScope(this);
@@ -119,17 +103,14 @@ namespace nadena.dev.ndmf.animator
         }
 
         /// <summary>
-        ///     Applies any in-scope AnimationOverrideControllers to the given motion to get the effective motion.
+        ///     Resolves AnimatorOverrideController mappings for the given clip.
+        ///     This method no longer performs any mapping (mappings are applied after cloning completes) and always
+        ///     returns the original clip.
         /// </summary>
-        /// <param name="clip"></param>
-        /// <returns></returns>
+        [Obsolete(
+            "This method never returned a non-identity mapping from externally-facing extension surfaces; it has no purpose and should not be used.")]
         public AnimationClip MapClipOnClone(AnimationClip clip)
         {
-            foreach (var controller in OverrideControllers)
-            {
-                clip = controller[clip];
-            }
-
             return clip;
         }
 
@@ -166,21 +147,27 @@ namespace nadena.dev.ndmf.animator
             }
             finally
             {
-                if (--_cloneDepth == 0)
-                {
-                    // Flush deferred actions. Note that deferred actions might spawn other clones, so be careful not
-                    // to recurse while flushing.
-                    try
-                    {
-                        _cloneDepth++;
+                if (--_cloneDepth == 0) FlushDeferredCalls();
+            }
+        }
 
-                        while (_deferredCalls.TryDequeue(out var action)) action();
-                    }
-                    finally
-                    {
-                        _cloneDepth--;
-                    }
-                }
+        /// <summary>
+        ///     Runs all deferred clone actions, including any spawned by previously deferred actions. Deferred actions exist
+        ///     only to bound recursion depth during cloning, so it is safe to flush them at an arbitrary point; animator
+        ///     controllers cannot be nested indefinitely.
+        /// </summary>
+        internal void FlushDeferredCalls()
+        {
+            // Note that deferred actions might spawn other clones, so be careful not to recurse while flushing.
+            _cloneDepth++;
+
+            try
+            {
+                while (_deferredCalls.TryDequeue(out var action)) action();
+            }
+            finally
+            {
+                _cloneDepth--;
             }
         }
 
@@ -293,7 +280,7 @@ namespace nadena.dev.ndmf.animator
         public void DeferCall(Action action)
         {
             var overrideStack = _curDynScope;
-            // Preserve ambient AnimatorOverrideController context when we defer calls
+            // Preserve ambient dynamic-scope state (innate animator key, layer mapper) when we defer calls
             if (_cloneDepth > 0)
                 _deferredCalls.Enqueue(() =>
                 {

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualAnimatorController.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualAnimatorController.cs
@@ -327,11 +327,102 @@ namespace nadena.dev.ndmf.animator
                 case AnimatorController ac: return new VirtualAnimatorController(context, ac);
                 case AnimatorOverrideController aoc:
                 {
-                    using var _ = context.PushOverrideController(aoc);
+                    // Clone distinct to ensure that we don't share any state with preexisting objects when we're about
+                    // to mutate them in-place.
+                    var result = context.CloneDistinct(aoc.runtimeAnimatorController);
 
-                    return Clone(context, aoc.runtimeAnimatorController);
+                    // Ensure all deferred clones (blend tree children, transitions) have run so the graph is fully
+                    // materialized before override mappings are resolved.
+                    context.FlushDeferredCalls();
+
+                    ApplyClipOverrides(result, context, aoc);
+
+                    return result;
                 }
                 default: throw new NotImplementedException($"Unknown controller type {controller.GetType()}");
+            }
+        }
+
+        /// <summary>
+        ///     Replaces the motions of states and blend tree children in a cloned controller with their
+        ///     AnimatorOverrideController mappings, if any.
+        ///     This is done after cloning so that every original clip gets exactly one clone keyed by itself; resolving
+        ///     overrides during cloning corrupts the clone cache when mappings are swapped or otherwise cyclic (#828).
+        /// </summary>
+        private static void ApplyClipOverrides(
+            VirtualAnimatorController controller,
+            CloneContext context,
+            AnimatorOverrideController aoc
+        )
+        {
+            foreach (var node in controller.AllReachableNodes())
+            {
+                switch (node)
+                {
+                    case VirtualState state:
+                        if (TryMapMotion(state.Motion, context, aoc) is VirtualMotion mappedStateMotion)
+                        {
+                            state.Motion = mappedStateMotion;
+                        }
+
+                        break;
+
+                    case VirtualBlendTree tree:
+                    {
+                        var changed = false;
+                        foreach (var child in tree.Children)
+                        {
+                            if (TryMapMotion(child.Motion, context, aoc) is VirtualMotion mappedChildMotion)
+                            {
+                                child.Motion = mappedChildMotion;
+                                changed = true;
+                            }
+                        }
+
+                        // Reassign to notify cache observers of the change.
+                        // (VirtualChildMotion is a bare class with no property setter on Motion to trigger cache
+                        // invalidation; this can't be changed without breaking IL-level compatibility)
+                        if (changed) tree.Children = tree.Children.ToImmutableList();
+
+                        break;
+                    }
+
+                    case VirtualLayer layer:
+                    {
+                        var changed = false;
+                        var builder = ImmutableDictionary.CreateBuilder<VirtualState, VirtualMotion>();
+                        foreach (var kvp in layer.SyncedLayerMotionOverrides)
+                        {
+                            if (TryMapMotion(kvp.Value, context, aoc) is VirtualMotion mappedOverride)
+                            {
+                                builder.Add(kvp.Key, mappedOverride);
+                                changed = true;
+                            }
+                            else
+                            {
+                                builder.Add(kvp.Key, kvp.Value);
+                            }
+                        }
+
+                        if (changed) layer.SyncedLayerMotionOverrides = builder.ToImmutable();
+
+                        break;
+                    }
+                }
+            }
+
+            static VirtualMotion? TryMapMotion(VirtualMotion? motion, CloneContext context, AnimatorOverrideController aoc)
+            {
+                if (motion is not VirtualClip clip) return null;
+
+                var original = (AnimationClip?)clip.OriginalObjectExposed;
+                if (original == null) return null;
+
+                // The indexer returns the original clip when no override is set for it.
+                var mapped = aoc[original];
+                if (mapped == null || ReferenceEquals(mapped, original)) return null;
+
+                return context.Clone(mapped);
             }
         }
 

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualClip.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualClip.cs
@@ -162,8 +162,6 @@ namespace nadena.dev.ndmf.animator
             AnimationClip clip
         )
         {
-            clip = cloneContext.MapClipOnClone(clip);
-
             return CloneWithoutOverrideController(cloneContext, clip);
         }
 

--- a/UnitTests~/AnimationServices/AnimatorOverrideControllerTest.cs
+++ b/UnitTests~/AnimationServices/AnimatorOverrideControllerTest.cs
@@ -124,5 +124,100 @@ namespace UnitTests.AnimationServices
             Assert.AreEqual("c3", virtualBlendTree.Children.First().Motion.Name);
             Assert.AreEqual("c2", virtualBlendTree.Children.Last().Motion.Name);
         }
+        /// <summary>
+        /// Regression test for https://github.com/bdunderscore/ndmf/issues/828
+        /// When an AOC swaps two clips (c1 -> c2 and c2 -> c1), both states must end up on the swapped
+        /// clip. Previously, cloning the first state cached the mapped clone under the target clip's key,
+        /// so the second state's lookup short-circuited before mapping was applied and both states ended
+        /// up playing the same (second) clip.
+        /// </summary>
+        [Test]
+        public void TestSwappedOverrides()
+        {
+            var objectRegistry = new ObjectRegistry(null);
+            var reg = (IObjectRegistry)objectRegistry;
+
+            var cloneContext = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+
+            var originalController = new AnimatorController();
+            var originalStateMachine = new AnimatorStateMachine();
+            originalController.layers = new[] {new AnimatorControllerLayer {stateMachine = originalStateMachine}};
+
+            var c1 = new AnimationClip {name = "c1"};
+            var c2 = new AnimationClip {name = "c2"};
+
+            var s1 = new AnimatorState {name = "s1", motion = c1};
+            var s2 = new AnimatorState {name = "s2", motion = c2};
+            originalStateMachine.states = new[] {new ChildAnimatorState {state = s1}, new ChildAnimatorState {state = s2}};
+            originalStateMachine.defaultState = s1;
+
+            var overrideController = new AnimatorOverrideController();
+            overrideController.runtimeAnimatorController = originalController;
+            // Swap the two clips in both directions.
+            overrideController[c1] = c2;
+            overrideController[c2] = c1;
+
+            VirtualAnimatorController virtualController;
+            AnimatorController committed;
+
+            using (new ObjectRegistryScope(objectRegistry))
+            {
+                virtualController = cloneContext.Clone(overrideController);
+
+                var commitContext = new CommitContext();
+                commitContext.NodeToReference = cloneContext.NodeToReference;
+                committed = commitContext.CommitObject(virtualController);
+            }
+
+            var stateMachine = committed.layers[0].stateMachine;
+            var committedS1 = (AnimationClip) stateMachine.states.First(s => s.state.name == "s1").state.motion;
+            var committedS2 = (AnimationClip) stateMachine.states.First(s => s.state.name == "s2").state.motion;
+
+            Assert.AreEqual("c2", committedS1.name);
+            Assert.AreEqual("c1", committedS2.name);
+            Assert.AreNotSame(committedS1, committedS2);
+
+            // Each state's clip must resolve to the reference of its mapped (swapped) source.
+            Assert.AreEqual(reg.GetReference(c2), reg.GetReference(committedS1));
+            Assert.AreEqual(reg.GetReference(c1), reg.GetReference(committedS2));
+        }
+        [Test]
+        public void TestSwappedOverridesInBlendTree()
+        {
+            var cloneContext = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+
+            var originalController = new AnimatorController();
+            originalController.AddParameter("Blend", AnimatorControllerParameterType.Float);
+            var originalStateMachine = new AnimatorStateMachine();
+            originalController.layers = new[] {new AnimatorControllerLayer {stateMachine = originalStateMachine}};
+
+            var c1 = new AnimationClip {name = "c1"};
+            var c2 = new AnimationClip {name = "c2"};
+
+            var bt1 = new BlendTree {name = "bt1", blendType = BlendTreeType.Simple1D};
+            bt1.children = new[] {new ChildMotion {motion = c1, timeScale = 1}, new ChildMotion {motion = c2, timeScale = 1}};
+            var bt2 = new BlendTree {name = "bt2", blendType = BlendTreeType.Simple1D};
+            bt2.children = new[] {new ChildMotion {motion = c2, timeScale = 1}, new ChildMotion {motion = c1, timeScale = 1}};
+
+            var s1 = new AnimatorState {name = "s1", motion = bt1};
+            var s2 = new AnimatorState {name = "s2", motion = bt2};
+            originalStateMachine.states = new[] {new ChildAnimatorState {state = s1}, new ChildAnimatorState {state = s2}};
+            originalStateMachine.defaultState = s1;
+
+            var overrideController = new AnimatorOverrideController();
+            overrideController.runtimeAnimatorController = originalController;
+            overrideController[c1] = c2;
+            overrideController[c2] = c1;
+
+            var virtualController = cloneContext.Clone(overrideController);
+            var stateMachine = virtualController.Layers.First().StateMachine;
+            var vbt1 = (VirtualBlendTree) stateMachine.States.Single(s => s.State.Name == "s1").State.Motion;
+            var vbt2 = (VirtualBlendTree) stateMachine.States.Single(s => s.State.Name == "s2").State.Motion;
+
+            Assert.AreEqual("c2", vbt1.Children.First().Motion.Name);
+            Assert.AreEqual("c1", vbt1.Children.Last().Motion.Name);
+            Assert.AreEqual("c1", vbt2.Children.First().Motion.Name);
+            Assert.AreEqual("c2", vbt2.Children.Last().Motion.Name);
+        }
     }
 }


### PR DESCRIPTION
Cloning an AOC previously resolved clip mappings inside VirtualClip.Clone, caching the mapped clone under the original clip's key. Swapped or cross-referencing mappings (A->B and B->A) then short-circuited on each other's cache entries, so both states ended up with the same clip in build output.

Mappings are now applied by a post-clone pass over AllReachableNodes once the base controller is cloned and all deferred clones have flushed (new CloneContext.FlushDeferredCalls), so every original clip gets exactly one clone keyed by itself. Nested AOCs compose as before, with inner mappings applied first.

CloneContext.MapClipOnClone no longer performs any mapping and is marked [Obsolete]; it will be removed in a future release.

Closes: #828
