### PR TITLE
fix: multiple small issues

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#830] Fixed a number of issues with error report object reference resolution
+- [#830] Fixed failed manual avatar processing leaving a generated avatar clone in the scene.
+- [#830] Fixed extension contexts being deactivated before contexts that depend on them
+- [#830] Fixed `BuildEnded` incorrectly reporting failed builds as successful.
+- [#830] Fixed stale animation-index/controller caches and incorrect layer behavior when virtual animator layers or object curves are removed or replaced.
+- [#830] Fixed `AsyncProfiler` nested scopes not restoring their parent profiling context when disposed.
+- [#830] Fixed parameter introspection throwing when queried for an object outside an avatar hierarchy.
+- [#830] Fixed ambiguous platform providers being selected arbitrarily instead of reported as an error.
+- [#830] Fixed generic-platform viseme initialization failing to update existing viseme shapes when their blendshape mapping changes.
+- [#830] Fixed generic PhysBone conversion skipping inactive PhysBones and losing adjusted radius-curve key times.
+- [#830] Fixed portable Dynamic Bone template selection throwing when the component is outside an avatar root.
+- [#830] Fixed NDMF preview continuing to render proxies for renderers returned by `PreviewSession.HiddenRenderers`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#830] Fixed a number of issues with error report object reference resolution
+- [#830] Fixed failed manual avatar processing leaving a generated avatar clone in the scene.
+- [#830] Fixed extension contexts being deactivated before contexts that depend on them
+- [#830] Fixed `BuildEnded` incorrectly reporting failed builds as successful.
+- [#830] Fixed stale animation-index/controller caches and incorrect layer behavior when virtual animator layers or object curves are removed or replaced.
+- [#830] Fixed `AsyncProfiler` nested scopes not restoring their parent profiling context when disposed.
+- [#830] Fixed parameter introspection throwing when queried for an object outside an avatar hierarchy.
+- [#830] Fixed ambiguous platform providers being selected arbitrarily instead of reported as an error.
+- [#830] Fixed generic-platform viseme initialization failing to update existing viseme shapes when their blendshape mapping changes.
+- [#830] Fixed generic PhysBone conversion skipping inactive PhysBones and losing adjusted radius-curve key times.
+- [#830] Fixed portable Dynamic Bone template selection throwing when the component is outside an avatar root.
+- [#830] Fixed NDMF preview continuing to render proxies for renderers returned by `PreviewSession.HiddenRenderers`.
 
 ### Changed
 

--- a/Editor/API/AnimatorServices/AnimationIndex.cs
+++ b/Editor/API/AnimatorServices/AnimationIndex.cs
@@ -379,6 +379,8 @@ namespace nadena.dev.ndmf.animator
             lastBindings.UnionWith(clip.GetObjectCurveBindings());
             lastBindings.UnionWith(clip.GetFloatCurveBindings());
 
+            _pptrClips.Remove(clip);
+
             if (clip.GetObjectCurveBindings().Any())
             {
                 _pptrClips.Add(clip);

--- a/Editor/API/AnimatorServices/CloneContext.cs
+++ b/Editor/API/AnimatorServices/CloneContext.cs
@@ -65,16 +65,18 @@ namespace nadena.dev.ndmf.animator
 
         private class DistinctScope : IDisposable
         {
+            private readonly CloneContext _context;
             private readonly Dictionary<object, object> _priorClones;
 
-            public DistinctScope(Dictionary<object, object> clones)
+            public DistinctScope(CloneContext context)
             {
-                _priorClones = clones;
+                _context = context;
+                _priorClones = context._clones;
             }
 
             public void Dispose()
             {
-                _priorClones.Clear();
+                _context._clones = _priorClones;
             }
         }
 
@@ -96,7 +98,7 @@ namespace nadena.dev.ndmf.animator
         /// <returns></returns>
         internal IDisposable PushDistinctScope()
         {
-            var scope = new DistinctScope(_clones);
+            var scope = new DistinctScope(this);
             _clones = new Dictionary<object, object>();
 
             return scope;

--- a/Editor/API/AnimatorServices/FilteredDictionaryView.cs
+++ b/Editor/API/AnimatorServices/FilteredDictionaryView.cs
@@ -76,14 +76,16 @@ namespace nadena.dev.ndmf.animator
         private readonly ISet<K> _filter;
         private readonly Func<K, I, V> _valueFilter;
         private readonly Action<K, V> _setterCallback;
+        private readonly Action<K>? _removalCallback;
 
         public FilteredDictionaryView(IDictionary<K, I> delegateDict, ISet<K> filter, Func<K, I, V> valueFilter,
-            Action<K, V> setterCallback)
+            Action<K, V> setterCallback, Action<K>? removalCallback = null)
         {
             _delegate = delegateDict;
             _filter = filter;
             _valueFilter = valueFilter;
             _setterCallback = setterCallback;
+            _removalCallback = removalCallback;
         }
 
         public IEnumerator<KeyValuePair<K, V>> GetEnumerator()
@@ -116,7 +118,9 @@ namespace nadena.dev.ndmf.animator
 
         public bool Remove(K key)
         {
-            return !_filter.Contains(key) && _delegate.Remove(key);
+            if (_filter.Contains(key) || !_delegate.Remove(key)) return false;
+            _removalCallback?.Invoke(key);
+            return true;
         }
 
         public bool TryGetValue(K key, out V value)
@@ -175,13 +179,19 @@ namespace nadena.dev.ndmf.animator
 
         public void Clear()
         {
-            var retained = _delegate.Where(kv => !!_filter.Contains(kv.Key)).ToList();
+            var removed = _delegate.Keys.Where(key => !_filter.Contains(key)).ToList();
+            var retained = _delegate.Where(kv => _filter.Contains(kv.Key)).ToList();
 
             _delegate.Clear();
 
             foreach (var pair in retained)
             {
                 _delegate.Add(pair);
+            }
+
+            foreach (var key in removed)
+            {
+                _removalCallback?.Invoke(key);
             }
         }
 
@@ -205,7 +215,7 @@ namespace nadena.dev.ndmf.animator
 
         public bool Remove(KeyValuePair<K, V> item)
         {
-            return Contains(item) && _delegate.Remove(item.Key);
+            return Contains(item) && Remove(item.Key);
         }
 
         public int Count => _delegate.Count - _filter.Where(_delegate.ContainsKey).Count();

--- a/Editor/API/AnimatorServices/VirtualControllerContext.cs
+++ b/Editor/API/AnimatorServices/VirtualControllerContext.cs
@@ -182,7 +182,8 @@ namespace nadena.dev.ndmf.animator
                 {
                     CacheInvalidationToken++;
                     _layerStates[k] = new LayerState(null) { VirtualController = v };
-                }
+                },
+                _ => CacheInvalidationToken++
             );
 
             #if NDMF_VRCSDK3_AVATARS

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualAnimatorController.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualAnimatorController.cs
@@ -269,6 +269,7 @@ namespace nadena.dev.ndmf.animator
                         _layers.Remove(priority);
                     }
                 }
+                _layerPriorities.Remove(layer);
             }
         }
 

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualAnimatorController.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualAnimatorController.cs
@@ -242,10 +242,11 @@ namespace nadena.dev.ndmf.animator
             get { return _layers.Values.SelectMany(l => l.Layers); }
             set
             {
+                var replacementLayers = value.ToList();
                 _layerPriorities.Clear();
                 _layers.Clear();
 
-                foreach (var layer in value)
+                foreach (var layer in replacementLayers)
                 {
                     AddLayer(new LayerPriority(0), layer);
                 }

--- a/Editor/API/AnimatorServices/VirtualObjects/VirtualAnimatorController.cs
+++ b/Editor/API/AnimatorServices/VirtualObjects/VirtualAnimatorController.cs
@@ -270,6 +270,7 @@ namespace nadena.dev.ndmf.animator
                     }
                 }
                 _layerPriorities.Remove(layer);
+                Invalidate();
             }
         }
 
@@ -295,6 +296,7 @@ namespace nadena.dev.ndmf.animator
                     _layers.Remove(prio);
                 }
             }
+            Invalidate();
         }
 
         /// <summary>

--- a/Editor/API/BuildContext.cs
+++ b/Editor/API/BuildContext.cs
@@ -135,7 +135,7 @@ namespace nadena.dev.ndmf
                     NDMFLocales.L, ErrorSeverity.Error,
                     "Errors:EditorOnlyAvatarRoot"
                 );
-                error.AddReference(ObjectRegistry.GetReference(obj));
+                error.AddReference(((IObjectRegistry)_registry).GetReference(obj));
                 _report.AddError(error);
                 ErrorReportWindow.ShowErrorReportWindow();
 

--- a/Editor/API/BuildContext.cs
+++ b/Editor/API/BuildContext.cs
@@ -546,28 +546,7 @@ namespace nadena.dev.ndmf
             using (new ExecutionScope(this))
             {
                 sw.Start();
-                foreach (var kvp in _activeExtensions.ToList())
-                {
-                    using (_report.WithExtensionContextTrace(kvp.Key))
-                    {
-                        try
-                        {
-                            kvp.Value.OnDeactivate(this);
-
-                            // ReSharper disable once SuspiciousTypeConversion.Global
-                            if (kvp.Value is IDisposable d)
-                            {
-                                d.Dispose();
-                            }
-                        }
-                        catch (Exception e)
-                        {
-                            ErrorReport.ReportException(e);
-                        }
-                    }
-
-                    _activeExtensions.Remove(kvp.Key);
-                }
+                DeactivateAllExtensionContexts();
 
                 RecalculateAllMeshes();
 

--- a/Editor/API/BuildContext.cs
+++ b/Editor/API/BuildContext.cs
@@ -553,7 +553,7 @@ namespace nadena.dev.ndmf
                 Serialize();
                 sw.Stop();
 
-                BuildEvent.Dispatch(new BuildEvent.BuildEnded(sw.ElapsedMilliseconds, true));
+                BuildEvent.Dispatch(new BuildEvent.BuildEnded(sw.ElapsedMilliseconds, _report.Errors.Count == 0));
 
                 if (!Application.isBatchMode && _report.Errors.Count > 0)
                 {

--- a/Editor/API/ObjectReference.cs
+++ b/Editor/API/ObjectReference.cs
@@ -79,7 +79,7 @@ namespace nadena.dev.ndmf
 
             if (av == null || _path == null) return false;
 
-            GameObject go = av.transform.Find(_path)?.gameObject;
+            GameObject go = _path.Length == 0 ? av : av.transform.Find(_path)?.gameObject;
 
             if (go == null) return false;
             if (Type == typeof(GameObject))

--- a/Editor/AsyncProfiler.cs
+++ b/Editor/AsyncProfiler.cs
@@ -71,7 +71,7 @@ namespace nadena.dev.ndmf
 
             _currentFrame.Value = newFrame;
 
-            return new PopFrame(newFrame);
+            return new PopFrame(currentFrame);
         }
 
         private class PopFrame : IDisposable
@@ -86,7 +86,8 @@ namespace nadena.dev.ndmf
             public void Dispose()
             {
                 var currentFrame = _currentFrame.Value;
-                if (currentFrame.Root != _targetFrame.Root || currentFrame.Depth < _targetFrame.Depth) return;
+                if (currentFrame?.Root != _targetFrame?.Root ||
+                    currentFrame?.Depth < _targetFrame?.Depth) return;
 
                 _currentFrame.Value = _targetFrame;
             }

--- a/Editor/AvatarProcessor.cs
+++ b/Editor/AvatarProcessor.cs
@@ -110,23 +110,31 @@ namespace nadena.dev.ndmf
             using (new OverrideTemporaryDirectoryScope("Assets/ZZZ_GeneratedAssets"))
             {
                 var avatar = UnityObject.Instantiate(obj);
-                platform ??= AmbientPlatform.CurrentPlatform;
-                var buildContext = new BuildContext(avatar, TemporaryAssetRoot, platform);
-
-                avatar.transform.position += Vector3.forward * 2f;
                 try
                 {
-                    AssetDatabase.StartAssetEditing();
-                    ProcessAvatar(buildContext, BuildPhase.BuiltInPhases.First(), BuildPhase.BuiltInPhases.Last());
+                    platform ??= AmbientPlatform.CurrentPlatform;
+                    var buildContext = new BuildContext(avatar, TemporaryAssetRoot, platform);
 
-                    buildContext.Finish();
+                    avatar.transform.position += Vector3.forward * 2f;
+                    try
+                    {
+                        AssetDatabase.StartAssetEditing();
+                        ProcessAvatar(buildContext, BuildPhase.BuiltInPhases.First(), BuildPhase.BuiltInPhases.Last());
 
-                    OnManualProcessAvatar?.Invoke(avatar, platform);
-                    return avatar;
+                        buildContext.Finish();
+
+                        OnManualProcessAvatar?.Invoke(avatar, platform);
+                        return avatar;
+                    }
+                    finally
+                    {
+                        AssetDatabase.StopAssetEditing();
+                    }
                 }
-                finally
+                catch
                 {
-                    AssetDatabase.StopAssetEditing();
+                    UnityObject.DestroyImmediate(avatar);
+                    throw;
                 }
             }
         }

--- a/Editor/ErrorReporting/ErrorReport.cs
+++ b/Editor/ErrorReporting/ErrorReport.cs
@@ -89,10 +89,11 @@ namespace nadena.dev.ndmf
         
         internal static List<ObjectReference> ReferenceStack = new List<ObjectReference>();
 
-        private ErrorReport(string avatarName, string avatarPath)
+        private ErrorReport(string avatarName, string avatarPath, Scene scene)
         {
             AvatarName = avatarName;
             AvatarRootPath = avatarPath;
+            Scene = scene;
             Errors = ImmutableList<ErrorContext>.Empty;
         }
 
@@ -104,6 +105,8 @@ namespace nadena.dev.ndmf
         /// The path (from the scene root) of the avatar being processed
         /// </summary>
         public string AvatarRootPath { get; }
+
+        internal Scene Scene { get; }
 
         /// <summary>
         /// A list of reported errors.
@@ -134,7 +137,7 @@ namespace nadena.dev.ndmf
                 path = path.Substring(0, path.Length - 7);
             }
 
-            var report = new ErrorReport(name, path);
+            var report = new ErrorReport(name, path, root.scene);
             Reports.Add(report);
 
             return report;
@@ -214,7 +217,7 @@ namespace nadena.dev.ndmf
         /// <returns>true if the avatar was found, otherwise false</returns>
         public bool TryResolveAvatar(out GameObject av)
         {
-            var scene = SceneManager.GetActiveScene();
+            var scene = Scene;
 
             var firstPathElement = AvatarRootPath.Split('/')[0];
             var remaining = firstPathElement == AvatarRootPath ? null : AvatarRootPath.Substring(firstPathElement.Length + 1);
@@ -330,7 +333,7 @@ namespace nadena.dev.ndmf
         /// <returns></returns>
         public static List<ErrorContext> CaptureErrors(Action action)
         {
-            var report = new ErrorReport("test avatar", "test avatar");
+            var report = new ErrorReport("test avatar", "test avatar", SceneManager.GetActiveScene());
             
             using (new ErrorReportScope(report))
             {

--- a/Editor/ErrorReporting/InlineError.cs
+++ b/Editor/ErrorReporting/InlineError.cs
@@ -31,6 +31,10 @@ namespace nadena.dev.ndmf
                 {
                     substitutions.Add("<missing>");
                 }
+                else if (arg is Object destroyedObject && destroyedObject == null)
+                {
+                    substitutions.Add("<missing>");
+                }
                 else if (arg is string s)
                 {
                     // string is IEnumerable, so we have to special case this

--- a/Editor/Platform/GenericPlatform.cs
+++ b/Editor/Platform/GenericPlatform.cs
@@ -114,7 +114,7 @@ namespace nadena.dev.ndmf.platform
             }
             
             visemes.TargetRenderer = info.VisemeRenderer;
-            visemes.Shapes.RemoveAll(s => s.Blendshape == null || !info.VisemeBlendshapes.ContainsKey(s.Blendshape));
+            visemes.Shapes.RemoveAll(s => s.VisemeName == null || !info.VisemeBlendshapes.ContainsKey(s.VisemeName));
 
             var toAdd = new Dictionary<string, string>(info.VisemeBlendshapes);
             for (int i = 0; i < visemes.Shapes.Count; i++)

--- a/Editor/Platform/PlatformRegistry.cs
+++ b/Editor/Platform/PlatformRegistry.cs
@@ -113,7 +113,7 @@ namespace nadena.dev.ndmf.platform
                 throw new Exception("Multiple avatar roots found in hierarchy.");
             }
 
-            if (candidateObjects.Count > 1)
+            if (platforms.Count > 1)
             {
                 if (platforms.Contains(GenericPlatform.Instance)) return GenericPlatform.Instance;
                 throw new Exception("Multiple platform providers found for avatar root: " +

--- a/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
+++ b/Editor/PreviewSystem/Rendering/ProxyPipeline.cs
@@ -91,7 +91,7 @@ namespace nadena.dev.ndmf.preview
 
         public IEnumerable<(Renderer, Renderer?)> Renderers
             => _proxies.Select(kvp => (kvp.Key, (Renderer?)kvp.Value.Renderer))
-                .Where(kvp => kvp.Key != null && !_hiddenRenderers.Contains(kvp.Item2!))
+                .Where(kvp => kvp.Key != null && !_hiddenRenderers.Contains(kvp.Key))
                 .Concat(_hiddenRenderers.Select(r => (r, (Renderer?)null)));
 
         public ProxyPipeline(

--- a/Editor/VRChat/ParameterIntrospection/ParameterInfo.cs
+++ b/Editor/VRChat/ParameterIntrospection/ParameterInfo.cs
@@ -137,7 +137,7 @@ namespace nadena.dev.ndmf
             ImmutableDictionary<(ParameterNamespace, string), ParameterMapping> mappings
                 = ImmutableDictionary<(ParameterNamespace, string), ParameterMapping>.Empty;
 
-            if (!RuntimeUtil.IsAvatarRoot(c.transform))
+            if (!RuntimeUtil.IsAvatarRoot(c.transform) && c.transform.parent != null)
             {
                 _computeContext.ObservePath(c.transform);
                 mappings = GetParameterRemappingsAt(c.transform.parent.gameObject);

--- a/Editor/VRChat/VRChatPlatformExtensions.cs
+++ b/Editor/VRChat/VRChatPlatformExtensions.cs
@@ -75,7 +75,7 @@ namespace nadena.dev.ndmf.multiplatform.editor
                 colliders[pbc] = portable;
             }
             
-            foreach (var pb in root.GetComponentsInChildren<VRCPhysBone>())
+            foreach (var pb in root.GetComponentsInChildren<VRCPhysBone>(true))
             {
                 var rootBone = pb.rootTransform ?? pb.transform;
                 var portable = explicitDynBones.GetValueOrDefault(rootBone) ??

--- a/Editor/VRChat/VRChatPlatformExtensions.cs
+++ b/Editor/VRChat/VRChatPlatformExtensions.cs
@@ -103,11 +103,12 @@ namespace nadena.dev.ndmf.multiplatform.editor
                     {
                         var maxBoneDepth =
                             (float)GetMaxBoneDepth(rootBone, new HashSet<Transform>(pb.ignoreTransforms));
-                        for (int i = 0; i < radiusCurve.keys.Length; i++)
+                        var keys = radiusCurve.keys;
+                        for (int i = 0; i < keys.Length; i++)
                         {
-                            radiusCurve.keys[i].time =
-                                radiusCurve.keys[i].time * (maxBoneDepth) / (maxBoneDepth + 1);
+                            keys[i].time = keys[i].time * maxBoneDepth / (maxBoneDepth + 1);
                         }
+                        radiusCurve.keys = keys;
                     }
 
                     portable.RadiusCurve.WeakSet(radiusCurve);

--- a/Runtime/Components/PortableDynamicBone.cs
+++ b/Runtime/Components/PortableDynamicBone.cs
@@ -40,12 +40,14 @@ namespace nadena.dev.ndmf.multiplatform.components
         public static string GuessTemplateName(Component pb, Transform root)
         {
             var rootPath = RuntimeUtil.AvatarRootPath(root.gameObject);
-            var path = RuntimeUtil.AvatarRootPath(pb.gameObject)!.ToLowerInvariant();
+            var path = RuntimeUtil.AvatarRootPath(pb.gameObject);
             
-            if (rootPath == null)
+            if (rootPath == null || path == null)
             {
                 return "generic";
             }
+
+            path = path.ToLowerInvariant();
             
             foreach (var segment in rootPath.Split("/"))
             {

--- a/Runtime/NonPersistentConfig.cs
+++ b/Runtime/NonPersistentConfig.cs
@@ -1,4 +1,6 @@
-﻿using UnityEditor;
+﻿#if UNITY_EDITOR
+using UnityEditor;
+#endif
 using UnityEngine;
 
 namespace nadena.dev.ndmf.config.runtime

--- a/Runtime/RuntimeUtil.cs
+++ b/Runtime/RuntimeUtil.cs
@@ -6,7 +6,9 @@ using System.Collections.Specialized;
 using System.Linq;
 using JetBrains.Annotations;
 using nadena.dev.ndmf.runtime.components;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityEngine;
 using UnityEngine.SceneManagement;
 #if NDMF_VRCSDK3_AVATARS

--- a/Runtime/SelfDestructComponent.cs
+++ b/Runtime/SelfDestructComponent.cs
@@ -1,7 +1,9 @@
 #region
 
 using System;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityEngine;
 
 #endregion

--- a/UnitTests~/AnimationServices/AnimationIndexTest.cs
+++ b/UnitTests~/AnimationServices/AnimationIndexTest.cs
@@ -449,6 +449,36 @@ namespace UnitTests.AnimationServices
             Assert.AreEqual(m1, newCurve[0].value);
             Assert.AreEqual(m3, newCurve[1].value);
         }
+
+        [Test]
+        public void RemovingObjectCurveRemovesClipFromPPtrCache()
+        {
+            var referencedObject = new AnimationClip();
+            try
+            {
+                var context = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+                var controller = VirtualAnimatorController.Create(context, "test");
+                var layer = controller.AddLayer(LayerPriority.Default, "test");
+                var clip = VirtualClip.Create("clip");
+                var binding = EditorCurveBinding.PPtrCurve("path", typeof(MeshRenderer), "m_Materials.Array.data[0]");
+                clip.SetObjectCurve(binding, new[]
+                {
+                    new ObjectReferenceKeyframe { time = 0, value = referencedObject }
+                });
+                layer.StateMachine!.AddState("state", motion: clip);
+                var index = new AnimationIndex(new[] { controller });
+
+                Assert.That(index.GetPPtrReferencedObjects, Is.EquivalentTo(new[] { referencedObject }));
+
+                clip.SetObjectCurve(binding, null);
+
+                Assert.IsEmpty(index.GetPPtrReferencedObjects);
+            }
+            finally
+            {
+                Object.DestroyImmediate(referencedObject);
+            }
+        }
     }
 }
 

--- a/UnitTests~/AnimationServices/CloneContextTests.cs
+++ b/UnitTests~/AnimationServices/CloneContextTests.cs
@@ -37,5 +37,20 @@ namespace UnitTests.AnimationServices
             Assert.AreEqual("hello, world", p.innateKey);
         }
 #endif
+
+        [Test]
+        public void DistinctScopeRestoresPriorCloneCache()
+        {
+            var context = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+            var source = new AnimationClip();
+            var originalClone = context.Clone(source);
+
+            using (context.PushDistinctScope())
+            {
+                Assert.AreNotSame(originalClone, context.Clone(source));
+            }
+
+            Assert.AreSame(originalClone, context.Clone(source));
+        }
     }
 }

--- a/UnitTests~/AnimationServices/GenericPlatformTests.cs
+++ b/UnitTests~/AnimationServices/GenericPlatformTests.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using nadena.dev.ndmf.animator;
 using nadena.dev.ndmf.UnitTestSupport;
 using NUnit.Framework;
+using nadena.dev.ndmf.platform;
+using nadena.dev.ndmf.runtime.components;
 using UnityEditor.Animations;
 using UnityEngine;
 
@@ -104,6 +107,29 @@ namespace UnitTests.AnimationServices
 
             var newController = (AnimatorController) childComponent.AnimatorController;
             Assert.AreEqual(1f, newController.layers[0].defaultWeight);
+        }
+
+        [Test]
+        public void NDMF0014_VisemeInitializationMatchesExistingShapeByVisemeName()
+        {
+            var avatar = CreateRoot("avatar");
+            var renderer = TrackObject(new GameObject("face")).AddComponent<SkinnedMeshRenderer>();
+            renderer.transform.SetParent(avatar.transform);
+            var visemes = avatar.AddComponent<PortableBlendshapeVisemes>();
+            visemes.TargetRenderer = renderer;
+            visemes.Shapes.Add(new PortableBlendshapeVisemes.Shape
+            {
+                VisemeName = "legacy",
+                Blendshape = CommonAvatarInfo.Viseme_aa
+            });
+            var info = new CommonAvatarInfo { VisemeRenderer = renderer };
+            info.VisemeBlendshapes[CommonAvatarInfo.Viseme_aa] = "new-blendshape";
+
+            Assert.DoesNotThrow(() => GenericPlatform.Instance.InitFromCommonAvatarInfo(avatar, info));
+            Assert.AreEqual(
+                "new-blendshape",
+                visemes.Shapes.Single(shape => shape.VisemeName == CommonAvatarInfo.Viseme_aa).Blendshape
+            );
         }
     }
 }

--- a/UnitTests~/AnimationServices/VirtualAnimatorControllerTest.cs
+++ b/UnitTests~/AnimationServices/VirtualAnimatorControllerTest.cs
@@ -263,18 +263,6 @@ namespace UnitTests.AnimationServices
             Assert.IsFalse(index.GetClipsForObjectPath("path").Any());
         }
 
-        [Test]
-        public void RemovedLayerCanBeAddedAgain()
-        {
-            var cloneContext = new CloneContext(GenericPlatformAnimatorBindings.Instance);
-            var controller = VirtualAnimatorController.Create(cloneContext);
-            var layer = controller.AddLayer(LayerPriority.Default, "layer");
-
-            controller.RemoveLayer(layer);
-            controller.AddLayer(new LayerPriority(1), layer);
-
-            Assert.That(controller.Layers, Is.EquivalentTo(new[] { layer }));
-        }
         
         
         [Test]

--- a/UnitTests~/AnimationServices/VirtualAnimatorControllerTest.cs
+++ b/UnitTests~/AnimationServices/VirtualAnimatorControllerTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -216,6 +216,51 @@ namespace UnitTests.AnimationServices
             Assert.AreEqual("t+10", layers[1].Name);
             Assert.AreEqual("t-10", layers[2].Name);
             Assert.AreEqual("t0.1", layers[3].Name);
+        }
+
+        [Test]
+        public void ReplacingLayersFromControllerEnumerationRetainsLayers()
+        {
+            var cloneContext = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+            var controller = VirtualAnimatorController.Create(cloneContext);
+            controller.AddLayer(LayerPriority.Default, "retained");
+            controller.AddLayer(LayerPriority.Default, "removed");
+
+            controller.Layers = controller.Layers.Where(layer => layer.Name == "retained");
+
+            CollectionAssert.AreEquivalent(new[] { "retained" }, controller.Layers.Select(layer => layer.Name));
+        }
+
+        [Test]
+        public void RemovedLayerCanBeAddedAgain()
+        {
+            var cloneContext = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+            var controller = VirtualAnimatorController.Create(cloneContext);
+            var layer = controller.AddLayer(LayerPriority.Default, "layer");
+
+            controller.RemoveLayer(layer);
+            controller.AddLayer(new LayerPriority(1), layer);
+
+            CollectionAssert.AreEquivalent(new[] { layer }, controller.Layers);
+        }
+
+        [Test]
+        public void RemovingLayerInvalidatesAnimationIndex()
+        {
+            var cloneContext = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+            var controller = VirtualAnimatorController.Create(cloneContext);
+            var layer = controller.AddLayer(LayerPriority.Default, "layer");
+            var clip = VirtualClip.Create("clip");
+            var binding = EditorCurveBinding.FloatCurve("path", typeof(Transform), "m_LocalPosition.x");
+            clip.SetFloatCurve(binding, AnimationCurve.Constant(0, 1, 1));
+            layer.StateMachine!.AddState("state", motion: clip);
+            var index = new AnimationIndex(new[] { controller });
+
+            CollectionAssert.AreEquivalent(new[] { clip }, index.GetClipsForObjectPath("path"));
+
+            controller.RemoveLayer(layer);
+
+            Assert.IsFalse(index.GetClipsForObjectPath("path").Any());
         }
         
         

--- a/UnitTests~/AnimationServices/VirtualAnimatorControllerTest.cs
+++ b/UnitTests~/AnimationServices/VirtualAnimatorControllerTest.cs
@@ -262,6 +262,19 @@ namespace UnitTests.AnimationServices
 
             Assert.IsFalse(index.GetClipsForObjectPath("path").Any());
         }
+
+        [Test]
+        public void RemovedLayerCanBeAddedAgain()
+        {
+            var cloneContext = new CloneContext(GenericPlatformAnimatorBindings.Instance);
+            var controller = VirtualAnimatorController.Create(cloneContext);
+            var layer = controller.AddLayer(LayerPriority.Default, "layer");
+
+            controller.RemoveLayer(layer);
+            controller.AddLayer(new LayerPriority(1), layer);
+
+            Assert.That(controller.Layers, Is.EquivalentTo(new[] { layer }));
+        }
         
         
         [Test]

--- a/UnitTests~/AnimationServices/VirtualControllerContextTests.cs
+++ b/UnitTests~/AnimationServices/VirtualControllerContextTests.cs
@@ -89,5 +89,35 @@ namespace UnitTests.AnimationServices
             Assert.NotNull(findFxLayer(root, "test_layer"));
         }
         #endif
+
+        [Test]
+        public void RemovingControllersInvalidatesControllerCache()
+        {
+            var context = CreateContext(CreateRoot("root"));
+            var controllerContext = context.ActivateExtensionContext<VirtualControllerContext>();
+            try
+            {
+                controllerContext.Controllers["removed"] =
+                    VirtualAnimatorController.Create(controllerContext.CloneContext, "removed");
+                var tokenBeforeRemove = controllerContext.CacheInvalidationToken;
+
+                Assert.IsTrue(controllerContext.Controllers.Remove("removed"));
+                Assert.Greater(controllerContext.CacheInvalidationToken, tokenBeforeRemove);
+
+                controllerContext.Controllers["first"] =
+                    VirtualAnimatorController.Create(controllerContext.CloneContext, "first");
+                controllerContext.Controllers["second"] =
+                    VirtualAnimatorController.Create(controllerContext.CloneContext, "second");
+                var tokenBeforeClear = controllerContext.CacheInvalidationToken;
+
+                controllerContext.Controllers.Clear();
+
+                Assert.Greater(controllerContext.CacheInvalidationToken, tokenBeforeClear);
+            }
+            finally
+            {
+                context.DeactivateExtensionContext<VirtualControllerContext>();
+            }
+        }
     }
 }

--- a/UnitTests~/AsyncProfilerTest.cs
+++ b/UnitTests~/AsyncProfilerTest.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Reflection;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+
+namespace UnitTests
+{
+    public class AsyncProfilerTest
+    {
+        [Test]
+        public void NDMF0024_DisposingNestedScopeRestoresParentFrame()
+        {
+            var currentFrameField = typeof(AsyncProfiler).GetField("_currentFrame", BindingFlags.Static | BindingFlags.NonPublic);
+            var currentFrame = currentFrameField.GetValue(null);
+            var valueProperty = currentFrame.GetType().GetProperty("Value");
+
+            using (AsyncProfiler.PushProfilerContext("parent"))
+            {
+                var child = AsyncProfiler.PushProfilerContext("child");
+                child.Dispose();
+
+                var restoredFrame = valueProperty.GetValue(currentFrame);
+                var contextField = restoredFrame.GetType().GetField("Context");
+                Assert.AreEqual("parent", contextField.GetValue(restoredFrame));
+            }
+        }
+    }
+}

--- a/UnitTests~/AsyncProfilerTest.cs.meta
+++ b/UnitTests~/AsyncProfilerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc187afcc5f671546932b49d7c3a75bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitTests~/AvatarProcessorTests.cs
+++ b/UnitTests~/AvatarProcessorTests.cs
@@ -1,0 +1,45 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace UnitTests
+{
+    public class AvatarProcessorTests : TestBase
+    {
+        [Test]
+        public void NDMF0005ManualProcessDestroysCloneWhenContextCreationFails()
+        {
+            var source = TrackObject(new GameObject($"NDMF-0005-{Guid.NewGuid():N}"));
+            source.tag = "EditorOnly";
+            var cloneName = source.name + "(Clone)";
+
+            try
+            {
+                Assert.That(
+                    () => AvatarProcessor.ManualProcessAvatar(source),
+                    Throws.TypeOf<Exception>()
+                );
+
+                Assert.That(
+                    Resources.FindObjectsOfTypeAll<GameObject>()
+                        .Where(obj => obj != source && obj.name == cloneName),
+                    Is.Empty
+                );
+            }
+            finally
+            {
+                foreach (var clone in Resources.FindObjectsOfTypeAll<GameObject>()
+                             .Where(obj => obj != source && obj.name == cloneName)
+                             .ToArray())
+                {
+                    Object.DestroyImmediate(clone);
+                }
+            }
+        }
+    }
+}

--- a/UnitTests~/AvatarProcessorTests.cs.meta
+++ b/UnitTests~/AvatarProcessorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9469cb7d14ad13c49962152f4147c576
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitTests~/BuildContextLifecycleTests.cs
+++ b/UnitTests~/BuildContextLifecycleTests.cs
@@ -1,0 +1,61 @@
+#nullable enable
+
+using System.Collections.Generic;
+using nadena.dev.ndmf;
+using NUnit.Framework;
+
+namespace UnitTests
+{
+    internal sealed class NDMF0003RequiredContext : IExtensionContext
+    {
+        internal static readonly List<string> DeactivationOrder = new();
+
+        public void OnActivate(BuildContext context)
+        {
+        }
+
+        public void OnDeactivate(BuildContext context)
+        {
+            DeactivationOrder.Add(nameof(NDMF0003RequiredContext));
+        }
+    }
+
+    [DependsOnContext(typeof(NDMF0003RequiredContext))]
+    internal sealed class NDMF0003DependentContext : IExtensionContext
+    {
+        public void OnActivate(BuildContext context)
+        {
+        }
+
+        public void OnDeactivate(BuildContext context)
+        {
+            NDMF0003RequiredContext.DeactivationOrder.Add(nameof(NDMF0003DependentContext));
+        }
+    }
+
+    public class BuildContextLifecycleTests : TestBase
+    {
+        [Test]
+        public void NDMF0003FinishDeactivatesDependentContextsBeforeTheirRequirements()
+        {
+            var context = new BuildContext(CreateRoot("NDMF-0003"), null);
+            NDMF0003RequiredContext.DeactivationOrder.Clear();
+
+            try
+            {
+                context.ActivateExtensionContextRecursive<NDMF0003DependentContext>();
+                context.Finish();
+
+                Assert.That(NDMF0003RequiredContext.DeactivationOrder, Is.EqualTo(new[]
+                {
+                    nameof(NDMF0003DependentContext),
+                    nameof(NDMF0003RequiredContext)
+                }));
+            }
+            finally
+            {
+                NDMF0003RequiredContext.DeactivationOrder.Clear();
+            }
+        }
+    }
+}

--- a/UnitTests~/BuildContextLifecycleTests.cs
+++ b/UnitTests~/BuildContextLifecycleTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using nadena.dev.ndmf;
@@ -103,6 +104,35 @@ namespace UnitTests
 
             var completion = BuildEvent.LastBuildEvents.OfType<BuildEvent.BuildEnded>().Single();
             Assert.That(completion.Successful, Is.False);
+        }
+
+        [Test]
+        public void NDMF0016EditorOnlyRootErrorUsesTheContextLocalObjectRegistry()
+        {
+            var root = CreateRoot("NDMF-0016");
+            root.tag = "EditorOnly";
+            var priorReports = ErrorReport.Reports.ToList();
+
+            try
+            {
+                using (new ObjectRegistryScope(new ObjectRegistry(null)))
+                {
+                    var exception = Assert.Throws<Exception>(() => new BuildContext(root, null));
+                    Assert.That(exception!.Message, Is.EqualTo(
+                        "Can't process an avatar whose root object is marked as EditorOnly"
+                    ));
+                }
+
+                var error = ErrorReport.Reports.Except(priorReports).Single().Errors.Single().TheError
+                    as SimpleError;
+                Assert.That(error, Is.Not.Null);
+                Assert.That(error!.References.Single().Object, Is.SameAs(root));
+                Assert.That(error.References.Single().Path, Is.EqualTo(""));
+            }
+            finally
+            {
+                ErrorReport.Reports.RemoveAll(report => !priorReports.Contains(report));
+            }
         }
     }
 }

--- a/UnitTests~/BuildContextLifecycleTests.cs
+++ b/UnitTests~/BuildContextLifecycleTests.cs
@@ -1,8 +1,12 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Linq;
 using nadena.dev.ndmf;
+using nadena.dev.ndmf.reporting;
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace UnitTests
 {
@@ -33,6 +37,37 @@ namespace UnitTests
         }
     }
 
+    internal sealed class NDMF0015ErrorContext : IExtensionContext
+    {
+        private sealed class BuildError : IError
+        {
+            public ErrorSeverity Severity => ErrorSeverity.Error;
+
+            public UnityEngine.UIElements.VisualElement CreateVisualElement(ErrorReport report)
+            {
+                return new UnityEngine.UIElements.VisualElement();
+            }
+
+            public string ToMessage()
+            {
+                return "NDMF-0015";
+            }
+
+            public void AddReference(ObjectReference obj)
+            {
+            }
+        }
+
+        public void OnActivate(BuildContext context)
+        {
+        }
+
+        public void OnDeactivate(BuildContext context)
+        {
+            ErrorReport.ReportError(new BuildError());
+        }
+    }
+
     public class BuildContextLifecycleTests : TestBase
     {
         [Test]
@@ -56,6 +91,18 @@ namespace UnitTests
             {
                 NDMF0003RequiredContext.DeactivationOrder.Clear();
             }
+        }
+
+        [Test]
+        public void NDMF0015FinishReportsAnUnsuccessfulBuildWhenErrorsWereRecorded()
+        {
+            var context = new BuildContext(CreateRoot("NDMF-0015"), null);
+            context.ActivateExtensionContext<NDMF0015ErrorContext>();
+
+            context.Finish();
+
+            var completion = BuildEvent.LastBuildEvents.OfType<BuildEvent.BuildEnded>().Single();
+            Assert.That(completion.Successful, Is.False);
         }
     }
 }

--- a/UnitTests~/BuildContextLifecycleTests.cs.meta
+++ b/UnitTests~/BuildContextLifecycleTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c296c56ea405af4b93e1e17417289e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitTests~/InlineErrorTests.cs
+++ b/UnitTests~/InlineErrorTests.cs
@@ -5,6 +5,8 @@ using nadena.dev.ndmf.localization;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
 
 namespace UnitTests
 {
@@ -98,6 +100,7 @@ namespace UnitTests
                 if (avatar != null) UnityEngine.Object.DestroyImmediate(avatar);
             }
         }
+
         [Test]
         public void TestEnumerableExpansion()
         {

--- a/UnitTests~/InlineErrorTests.cs
+++ b/UnitTests~/InlineErrorTests.cs
@@ -32,6 +32,24 @@ namespace UnitTests
         }
         
         [Test]
+        public void NDMF0020_DestroyedUnityObjectFormatsAsMissing()
+        {
+            var destroyedObject = new GameObject("destroyed");
+            try
+            {
+                UnityEngine.Object.DestroyImmediate(destroyedObject);
+
+                var error = new InlineError(TEST_LOCALIZER, ErrorSeverity.Error, "Errors:test", destroyedObject);
+
+                Assert.AreEqual("Test error <missing>", error.FormatTitle());
+            }
+            finally
+            {
+                if (destroyedObject != null) UnityEngine.Object.DestroyImmediate(destroyedObject);
+            }
+        }
+        
+        [Test]
         public void TestEnumerableExpansion()
         {
             var or1 = new ObjectReference(null, "a");

--- a/UnitTests~/InlineErrorTests.cs
+++ b/UnitTests~/InlineErrorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using nadena.dev.ndmf;
 using nadena.dev.ndmf.localization;
@@ -48,7 +48,56 @@ namespace UnitTests
                 if (destroyedObject != null) UnityEngine.Object.DestroyImmediate(destroyedObject);
             }
         }
-        
+
+        [Test]
+        public void NDMF0021_ErrorReportResolvesAvatarFromItsOriginatingAdditiveScene()
+        {
+            var activeScenePath = "Assets/NDMF0021_ActiveScene.unity";
+            var activeScene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            EditorSceneManager.SaveScene(activeScene, activeScenePath);
+            var testScene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Additive);
+            Assert.IsTrue(SceneManager.SetActiveScene(activeScene));
+            var avatar = new GameObject("test avatar");
+            SceneManager.MoveGameObjectToScene(avatar, testScene);
+
+            try
+            {
+                Assert.AreNotEqual(testScene, SceneManager.GetActiveScene());
+
+                var report = ErrorReport.Create(avatar, false);
+                Assert.IsTrue(report.TryResolveAvatar(out var resolvedAvatar));
+                Assert.AreSame(avatar, resolvedAvatar);
+            }
+            finally
+            {
+                if (avatar != null) UnityEngine.Object.DestroyImmediate(avatar);
+                EditorSceneManager.CloseScene(testScene, true);
+                AssetDatabase.DeleteAsset(activeScenePath);
+            }
+        }
+
+        [Test]
+        public void NDMF0022_ResolveEmptyReferencePathToAvatarRoot()
+        {
+            var avatar = new GameObject("avatar");
+            try
+            {
+                using (new ObjectRegistryScope(new ObjectRegistry(avatar.transform)))
+                {
+                    var reference = ObjectRegistry.GetReference(avatar);
+                    var report = ErrorReport.Create(avatar, false);
+
+                    Assert.AreEqual("", reference.Path);
+                    Assert.IsTrue(reference.TryResolve(report, out var resolvedObject));
+                    Assert.AreSame(avatar, resolvedObject);
+                }
+            }
+            finally
+            {
+                ErrorReport.Clear();
+                if (avatar != null) UnityEngine.Object.DestroyImmediate(avatar);
+            }
+        }
         [Test]
         public void TestEnumerableExpansion()
         {

--- a/UnitTests~/PluginResolverTests/PlatformFilteringTest.cs
+++ b/UnitTests~/PluginResolverTests/PlatformFilteringTest.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Immutable;
+using System.Reflection;
+using UnityEngine;
+using System.Collections.Generic;
 using System.Linq;
 using nadena.dev.ndmf;
 using nadena.dev.ndmf.platform;
@@ -13,6 +17,30 @@ namespace UnitTests.PluginResolverTests
     {
         public string QualifiedName => "test-platform";
         public string DisplayName => "test-platform";
+    }
+
+    class AmbiguousPlatformRootA : MonoBehaviour
+    {
+    }
+
+    class AmbiguousPlatformRootB : MonoBehaviour
+    {
+    }
+
+    class AmbiguousPlatformProvider : INDMFPlatformProvider
+    {
+        private readonly string _qualifiedName;
+        private readonly Type _avatarRootComponentType;
+
+        public AmbiguousPlatformProvider(string qualifiedName, Type avatarRootComponentType)
+        {
+            _qualifiedName = qualifiedName;
+            _avatarRootComponentType = avatarRootComponentType;
+        }
+
+        public string QualifiedName => _qualifiedName;
+        public string DisplayName => _qualifiedName;
+        public Type AvatarRootComponentType => _avatarRootComponentType;
     }
     
     class DefaultPlatformPlugin : Plugin<DefaultPlatformPlugin>
@@ -157,6 +185,31 @@ namespace UnitTests.PluginResolverTests
                 .First(pass => pass.Skipped && pass.Plugin.QualifiedName == NeverRunsPlugin.Instance.QualifiedName);
             
             pass.Execute(CreateContext(CreateRoot("root")));
+        }
+
+        [Test]
+        public void NDMF0009_ThrowsWhenTwoProvidersMatchOneAvatarRoot()
+        {
+            var root = CreateRoot("avatar");
+            root.AddComponent<AmbiguousPlatformRootA>();
+            root.AddComponent<AmbiguousPlatformRootB>();
+            var registryField = typeof(PlatformRegistry).GetField(
+                "_platformProviders", BindingFlags.Static | BindingFlags.NonPublic);
+            var originalRegistry = registryField.GetValue(null);
+            var providers = ImmutableDictionary<string, INDMFPlatformProvider>.Empty
+                .Add("first", new AmbiguousPlatformProvider("first", typeof(AmbiguousPlatformRootA)))
+                .Add("second", new AmbiguousPlatformProvider("second", typeof(AmbiguousPlatformRootB)));
+
+            try
+            {
+                registryField.SetValue(null, providers);
+
+                Assert.Throws<Exception>(() => PlatformRegistry.GetPrimaryPlatformForAvatar(root));
+            }
+            finally
+            {
+                registryField.SetValue(null, originalRegistry);
+            }
         }
     }
 }

--- a/UnitTests~/PortableDynamicBoneTests.cs
+++ b/UnitTests~/PortableDynamicBoneTests.cs
@@ -1,0 +1,38 @@
+using nadena.dev.ndmf.multiplatform.components;
+using NUnit.Framework;
+using UnityEngine;
+#if NDMF_VRCSDK3_AVATARS
+using nadena.dev.ndmf.vrchat;
+using VRC.SDK3.Dynamics.PhysBone.Components;
+#endif
+
+namespace UnitTests
+{
+    public class PortableDynamicBoneTests : TestBase
+    {
+        [Test]
+        public void NDMF0025_OutsideAvatarRootUsesGenericTemplate()
+        {
+            var root = TrackObject(new GameObject("root"));
+            var dynamicBone = TrackObject(new GameObject("dynamic-bone")).AddComponent<PortableDynamicBone>();
+
+            Assert.DoesNotThrow(() =>
+                Assert.AreEqual("generic", PortableDynamicBone.GuessTemplateName(dynamicBone, root.transform)));
+        }
+        #if NDMF_VRCSDK3_AVATARS
+        [Test]
+        public void NDMF0018_ConvertsInactivePhysBoneInEditMode()
+        {
+            var avatar = CreateRoot("avatar");
+            var physBoneObject = CreateChild(avatar, "inactive physbone");
+            var physBone = physBoneObject.AddComponent<VRCPhysBone>();
+            physBoneObject.SetActive(false);
+
+            VRChatPlatform.Instance.GeneratePortableComponents(avatar, false);
+
+            Assert.AreSame(physBoneObject, physBone.GetComponent<PortableDynamicBone>().gameObject);
+        }
+        #endif
+    }
+}
+

--- a/UnitTests~/PortableDynamicBoneTests.cs
+++ b/UnitTests~/PortableDynamicBoneTests.cs
@@ -35,4 +35,3 @@ namespace UnitTests
         #endif
     }
 }
-

--- a/UnitTests~/PortableDynamicBoneTests.cs.meta
+++ b/UnitTests~/PortableDynamicBoneTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 44cf76f454ffc394181794659ce33d4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- **fix: guard runtime editor imports**
- **fix: clips could be inappropriately cloned when an override controller was present**
- **fix: ensure extension components are deactivated in topo-order**
- **fix: delete cloned avatar when manual bake fails**
- **fix: unsafe enumeration when setting animator layers**
- **fix: clear layer priority when layer is removed**
- **fix: missing animation cache invalidations**
- **fix: detect platform provider ambiguity**
- **fix: filter renderers hidden by PreviewSession.HiddenRenderers correctly**
- **fix: validate generic visemes by viseme name, not shape**
- **fix: report actual build completion status**
- **fix: use local registry for constructor errors**
- **fix: avoid exception when parameter info queried outside an avatar**
- **fix: include inactive PhysBones in generic-PB conversion**
- **fix: persist adjusted PhysBone radius keys in generic conversion**
- **fix: handle destroyed inline error arguments**
- **fix: resolve error reports in originating scene**
- **fix: resolve empty object reference paths to avatar root**
- **fix: restore async profiler parent frame correctly**
- **fix: null-check dynamic bone avatar path**
- **chore: CHANGELOGs**
